### PR TITLE
Implement Add and Clear Medicine Usage functionalities

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateUtil.java
@@ -38,6 +38,10 @@ public class DateUtil {
         return dateTime.format(DATE_TIME_DISPLAY_FORMATTER);
     }
 
+    public static DateTimeFormatter getDateFormatter() {
+        return DATE_FORMATTER;
+    }
+
     /**
      * Check if date is current date
      */

--- a/src/main/java/seedu/address/commons/util/DateUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateUtil.java
@@ -42,6 +42,10 @@ public class DateUtil {
         return DATE_FORMATTER;
     }
 
+    public static DateTimeFormatter getDisplayDateFormatter() {
+        return DATE_DISPLAY_FORMATTER;
+    }
+
     /**
      * Check if date is current date
      */

--- a/src/main/java/seedu/address/logic/commands/AddMedicineUsageCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMedicineUsageCommand.java
@@ -1,0 +1,76 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DOSAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FROM;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.medicineusage.MedicineUsage;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds a medicine usage to a person by NRIC.
+ */
+public class AddMedicineUsageCommand extends Command {
+
+    public static final String COMMAND_WORD = "addmu";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Adds a medicine usage to a person identified by NRIC.\n"
+            + "Parameters: "
+            + PREFIX_NRIC + "NRIC "
+            + PREFIX_NAME + "MEDICINE NAME "
+            + PREFIX_DOSAGE + "DOSAGE "
+            + PREFIX_FROM + "START DATE (dd-MM-yyyy) "
+            + PREFIX_TO + "END DATE (dd-MM-yyyy)\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NRIC + "S1234567A "
+            + PREFIX_NAME + "Paracetamol "
+            + PREFIX_DOSAGE + "Two 500mg tablets, 4 times in 24 hours "
+            + PREFIX_FROM + "23-02-2025 "
+            + PREFIX_TO + "27-02-2025\n";
+
+    public static final String MESSAGE_SUCCESS = "Medicine usage successfully added to %s";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "Person with NRIC %s not found";
+
+    private final Nric nric;
+    private final MedicineUsage medicineUsage;
+
+    /**
+     * Creates an AddMedicineUsageCommand to add the specified {@code MedicineUsage}
+     * to the person identified by {@code Nric}.
+     */
+    public AddMedicineUsageCommand(Nric nric, MedicineUsage medicineUsage) {
+        requireNonNull(nric);
+        requireNonNull(medicineUsage);
+        this.nric = nric;
+        this.medicineUsage = medicineUsage;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        Person person = model.findPersonByNric(nric);
+        if (person == null) {
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND, nric));
+        }
+
+        model.addMedicineUsage(person, medicineUsage);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, nric));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof AddMedicineUsageCommand
+                && nric.equals(((AddMedicineUsageCommand) other).nric)
+                && medicineUsage.equals(((AddMedicineUsageCommand) other).medicineUsage));
+    }
+}
+

--- a/src/main/java/seedu/address/logic/commands/ClearMedicineUsageCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearMedicineUsageCommand.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+
+/**
+ * Clears all medicine usages of a person by NRIC.
+ */
+public class ClearMedicineUsageCommand extends Command {
+
+    public static final String COMMAND_WORD = "clearmu";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Clears all medicine usages of a person identified by NRIC.\n"
+            + "Parameters: "
+            + PREFIX_NRIC + "NRIC\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NRIC + "S1234567A\n";
+
+    public static final String MESSAGE_SUCCESS = "Medicine usages successfully deleted from %s";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "Person with NRIC %s not found";
+
+    private final Nric nric;
+
+    /**
+     * Creates an ClearMedicineUsageCommand to delete all medicine usages of
+     * the person identified by {@code Nric}.
+     */
+    public ClearMedicineUsageCommand(Nric nric) {
+        requireNonNull(nric);
+        this.nric = nric;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        Person person = model.findPersonByNric(nric);
+        if (person == null) {
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND, nric));
+        }
+
+        model.clearMedicineUsage(person);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, nric));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof ClearMedicineUsageCommand
+                && nric.equals(((ClearMedicineUsageCommand) other).nric));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddMedicineUsageCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMedicineUsageCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import seedu.address.commons.util.DateUtil;

--- a/src/main/java/seedu/address/logic/parser/AddMedicineUsageCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMedicineUsageCommandParser.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DOSAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FROM;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TO;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import seedu.address.commons.util.DateUtil;
+import seedu.address.logic.commands.AddMedicineUsageCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.medicineusage.MedicineUsage;
+import seedu.address.model.person.Nric;
+
+/**
+ * Parses input arguments and creates a new AddMedicalReportCommand object
+ */
+public class AddMedicineUsageCommandParser implements Parser<AddMedicineUsageCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddMedicineUsageCommand
+     * and returns an AddMedicineUsage object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddMedicineUsageCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_NAME, PREFIX_DOSAGE, PREFIX_FROM, PREFIX_TO);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_NAME, PREFIX_DOSAGE, PREFIX_FROM, PREFIX_TO)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddMedicineUsageCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_NAME, PREFIX_DOSAGE, PREFIX_FROM, PREFIX_TO);
+
+        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        String name = argMultimap.getValue(PREFIX_NAME).get();
+        String dosage = argMultimap.getValue(PREFIX_DOSAGE).get();
+        LocalDate startDate = LocalDate.parse(argMultimap.getValue(PREFIX_FROM).get(),
+                DateUtil.getDateFormatter());
+        LocalDate endDate = LocalDate.parse(argMultimap.getValue(PREFIX_TO).get(),
+                DateUtil.getDateFormatter());
+
+        MedicineUsage medicineUsage = new MedicineUsage(name, dosage, startDate, endDate);
+
+        return new AddMedicineUsageCommand(nric, medicineUsage);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ClearMedicineUsageCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearMedicineUsageCommandParser.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.ClearMedicineUsageCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Nric;
+
+/**
+ * Parses input arguments and creates a new AddMedicalReportCommand object
+ */
+public class ClearMedicineUsageCommandParser implements Parser<ClearMedicineUsageCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddMedicineUsageCommand
+     * and returns an AddMedicineUsage object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ClearMedicineUsageCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ClearMedicineUsageCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC);
+
+        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+
+        return new ClearMedicineUsageCommand(nric);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/KlinixParser.java
+++ b/src/main/java/seedu/address/logic/parser/KlinixParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddMedicalReportCommand;
 import seedu.address.logic.commands.AddMedicineUsageCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearMedicineUsageCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteMedicalReportCommand;
@@ -88,6 +89,8 @@ public class KlinixParser {
         case AddMedicineUsageCommand.COMMAND_WORD:
             return new AddMedicineUsageCommandParser().parse(arguments);
 
+        case ClearMedicineUsageCommand.COMMAND_WORD:
+            return new ClearMedicineUsageCommandParser().parse(arguments);
         default:
             logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/KlinixParser.java
+++ b/src/main/java/seedu/address/logic/parser/KlinixParser.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddMedicalReportCommand;
+import seedu.address.logic.commands.AddMedicineUsageCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -31,7 +32,6 @@ public class KlinixParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(KlinixParser.class);
-
     /**
      * Parses user input into command for execution.
      *
@@ -84,6 +84,9 @@ public class KlinixParser {
 
         case DeleteMedicalReportCommand.COMMAND_WORD:
             return new DeleteMedicalReportCommandParser().parse(arguments);
+
+        case AddMedicineUsageCommand.COMMAND_WORD:
+            return new AddMedicineUsageCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -104,12 +104,17 @@ public interface Model {
     void deleteMedicalReport(Person target);
 
     /**
-     * Adds medicine usage to a person
+     * Adds a medicine usage to a person
      */
     void addMedicineUsage(Person target, MedicineUsage medicineUsage);
 
     /**
-     * Deletes medicine usage from a person.
+     * Deletes a medicine usage from a person.
      */
     void deleteMedicineUsage(Person target, MedicineUsage medicineUsage);
+
+    /**
+     * Clears all medicine usages from a person
+     */
+    void clearMedicineUsage(Person target);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.medicineusage.MedicineUsage;
 import seedu.address.model.person.MedicalReport;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
@@ -101,4 +102,14 @@ public interface Model {
      * Deletes medical report from the person.
      */
     void deleteMedicalReport(Person target);
+
+    /**
+     * Adds medicine usage to a person
+     */
+    void addMedicineUsage(Person target, MedicineUsage medicineUsage);
+
+    /**
+     * Deletes medicine usage from a person.
+     */
+    void deleteMedicineUsage(Person target, MedicineUsage medicineUsage);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -167,6 +167,7 @@ public class ModelManager implements Model {
         requireAllNonNull(target, medicineUsage);
         MedicalReport medicalReport = target.getMedicalReport();
         medicalReport.add(medicineUsage);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
@@ -174,6 +175,7 @@ public class ModelManager implements Model {
         requireAllNonNull(target, medicineUsage);
         MedicalReport medicalReport = target.getMedicalReport();
         medicalReport.remove(medicineUsage);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
     //=========== Filtered Person List Accessors =============================================================
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -177,6 +177,14 @@ public class ModelManager implements Model {
         medicalReport.remove(medicineUsage);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
+
+    @Override
+    public void clearMedicineUsage(Person target) {
+        requireNonNull(target);
+        MedicalReport medicalReport = target.getMedicalReport();
+        medicalReport.reset();
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.medicineusage.MedicineUsage;
 import seedu.address.model.person.MedicalReport;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
@@ -160,6 +161,20 @@ public class ModelManager implements Model {
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
+    //=========== Medicine Usage =============================================================================
+    @Override
+    public void addMedicineUsage(Person target, MedicineUsage medicineUsage) {
+        requireAllNonNull(target, medicineUsage);
+        MedicalReport medicalReport = target.getMedicalReport();
+        medicalReport.add(medicineUsage);
+    }
+
+    @Override
+    public void deleteMedicineUsage(Person target, MedicineUsage medicineUsage) {
+        requireAllNonNull(target, medicineUsage);
+        MedicalReport medicalReport = target.getMedicalReport();
+        medicalReport.remove(medicineUsage);
+    }
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
@@ -4,6 +4,8 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
 
+import seedu.address.model.person.Person;
+
 /**
  * Represents a Medicine Usage of a patient in the clinic.
  */
@@ -45,8 +47,30 @@ public class MedicineUsage {
     }
 
     /**
-     * Returns true if both persons have the same identity and data fields.
-     * This defines a stronger notion of equality between two persons.
+     * Returns true if both medicine usages have the same name and overlapping time.
+     * This defines a weaker notion of equality between two medicine usages.
+     */
+
+    public boolean hasOverlap(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MedicineUsage)) {
+            return false;
+        }
+
+        MedicineUsage otherMedicineUsage = (MedicineUsage) other;
+        boolean hasNoTimeOverlap = otherMedicineUsage.getStartDate().isAfter(this.getEndDate())
+                || otherMedicineUsage.getEndDate().isBefore(this.getStartDate());
+
+        return otherMedicineUsage.getName().equals(this.getName()) && !hasNoTimeOverlap;
+    }
+
+    /**
+     * Returns true if both medicine usages have the same identity and data fields.
+     * This defines a stronger notion of equality between two medicine usages.
      */
     @Override
     public boolean equals(Object other) {
@@ -60,9 +84,10 @@ public class MedicineUsage {
         }
 
         MedicineUsage otherMedicineUsage = (MedicineUsage) other;
-        boolean isDateTimeSeparate = otherMedicineUsage.getStartDate().isAfter(this.getEndDate())
-                || otherMedicineUsage.getEndDate().isBefore(this.getStartDate());
-
-        return otherMedicineUsage.getName().equals(this.getName()) && !isDateTimeSeparate;
+        return name.equals(otherMedicineUsage.name)
+                && dosage.equals(otherMedicineUsage.dosage)
+                && startDate.equals(otherMedicineUsage.startDate)
+                && endDate.equals(otherMedicineUsage.endDate);
     }
+
 }

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
@@ -4,6 +4,8 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDate;
 
+import seedu.address.commons.util.DateUtil;
+
 /**
  * Represents a Medicine Usage of a patient in the clinic.
  */
@@ -44,6 +46,14 @@ public class MedicineUsage {
         return endDate;
     }
 
+    public String getStringStartDate() {
+        return DateUtil.getDisplayableDate(startDate);
+    }
+
+    public String getStringEndDate() {
+        return DateUtil.getDisplayableDate(endDate);
+    }
+
     /**
      * Returns true if both medicine usages have the same name.
      * This defines the weakest notion of equality between two medicine usages.
@@ -62,21 +72,15 @@ public class MedicineUsage {
      * This defines a weak notion of equality between two medicine usages.
      */
 
-    public boolean hasOverlap(Object other) {
+    public boolean hasOverlap(MedicineUsage other) {
         if (other == this) {
             return true;
         }
 
-        // instanceof handles nulls
-        if (!(other instanceof MedicineUsage)) {
-            return false;
-        }
+        boolean hasNoTimeOverlap = other.getStartDate().isAfter(this.getEndDate())
+                || other.getEndDate().isBefore(this.getStartDate());
 
-        MedicineUsage otherMedicineUsage = (MedicineUsage) other;
-        boolean hasNoTimeOverlap = otherMedicineUsage.getStartDate().isAfter(this.getEndDate())
-                || otherMedicineUsage.getEndDate().isBefore(this.getStartDate());
-
-        return otherMedicineUsage.getName().equals(this.getName()) && !hasNoTimeOverlap;
+        return other.getName().equals(this.getName()) && !hasNoTimeOverlap;
     }
 
     /**
@@ -99,6 +103,13 @@ public class MedicineUsage {
                 && dosage.equals(otherMedicineUsage.dosage)
                 && startDate.equals(otherMedicineUsage.startDate)
                 && endDate.equals(otherMedicineUsage.endDate);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s, %s, from %s to %s", name, dosage,
+                DateUtil.getDisplayableDate(startDate),
+                DateUtil.getDisplayableDate(endDate));
     }
 
 }

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
@@ -2,9 +2,7 @@ package seedu.address.model.medicineusage;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.time.LocalDateTime;
-
-import seedu.address.model.person.Person;
+import java.time.LocalDate;
 
 /**
  * Represents a Medicine Usage of a patient in the clinic.
@@ -12,8 +10,8 @@ import seedu.address.model.person.Person;
 public class MedicineUsage {
     private final String name;
     private final String dosage;
-    private final LocalDateTime startDate;
-    private final LocalDateTime endDate;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
 
     /**
      * Constructs a MedicineUsage object
@@ -22,7 +20,7 @@ public class MedicineUsage {
      * @param startDate Patient starts taking medicine on this date
      * @param endDate Patient stops taking medicine on this date
      */
-    public MedicineUsage(String name, String dosage, LocalDateTime startDate, LocalDateTime endDate) {
+    public MedicineUsage(String name, String dosage, LocalDate startDate, LocalDate endDate) {
         requireAllNonNull(name, dosage, startDate, endDate);
         this.name = name;
         this.dosage = dosage;
@@ -38,11 +36,11 @@ public class MedicineUsage {
         return dosage;
     }
 
-    public LocalDateTime getStartDate() {
+    public LocalDate getStartDate() {
         return startDate;
     }
 
-    public LocalDateTime getEndDate() {
+    public LocalDate getEndDate() {
         return endDate;
     }
 

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
@@ -47,8 +47,21 @@ public class MedicineUsage {
     }
 
     /**
+     * Returns true if both medicine usages have the same name.
+     * This defines the weakest notion of equality between two medicine usages.
+     */
+
+    public boolean isSameMedicine(MedicineUsage otherMedicineUsage) {
+        if (otherMedicineUsage == this) {
+            return true;
+        }
+
+        return otherMedicineUsage != null && otherMedicineUsage.getName().equals(getName());
+    }
+
+    /**
      * Returns true if both medicine usages have the same name and overlapping time.
-     * This defines a weaker notion of equality between two medicine usages.
+     * This defines a weak notion of equality between two medicine usages.
      */
 
     public boolean hasOverlap(Object other) {

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
@@ -10,7 +10,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.medicineusage.exceptions.MedicineUsageNotFoundException;
 import seedu.address.model.medicineusage.exceptions.OverlappingMedicineUsageException;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
 
 /**
  * A list of medicine usages that enforces uniqueness between its elements and does not allow nulls.
@@ -93,7 +92,7 @@ public class MedicineUsageList implements Iterable<MedicineUsage> {
     public void setMedicineUsages(List<MedicineUsage> replacement) {
         requireAllNonNull(replacement);
         if (!medicineUsagesAreUnique(replacement)) {
-            throw new DuplicatePersonException();
+            throw new OverlappingMedicineUsageException();
         }
 
         internalList.setAll(replacement);

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
@@ -1,4 +1,141 @@
 package seedu.address.model.medicineusage;
 
-public class MedicineUsageList {
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.medicineusage.exceptions.MedicineUsageNotFoundException;
+import seedu.address.model.medicineusage.exceptions.OverlappingMedicineUsageException;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+
+/**
+ * A list of medicine usages that enforces uniqueness between its elements and does not allow nulls.
+ * A medicine usage is considered unique by comparing using {@code MedicineUsage#hasOverlap(MedicineUsage)}.
+ * As such, adding and updating of medicine usages uses MedicineUsage#hasOverlap(MedicineUsage) for equality
+ * to ensure that the medicine usage being added or updated is unique in terms of identity in the
+ * MedicineUsageList. However, the removal of a person uses MedicineUsage#equals(Object) to ensure that the
+ * medicine usage with exactly the same fields will be removed.
+ * Supports a minimal set of list operations.
+ *
+ * @see Person#isSamePerson(Person)
+ */
+public class MedicineUsageList implements Iterable<MedicineUsage> {
+    private final ObservableList<MedicineUsage> internalList = FXCollections.observableArrayList();
+    private final ObservableList<MedicineUsage> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an overlap of medicine usage with the given argument.
+     */
+    public boolean containsOverlap(MedicineUsage toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::hasOverlap);
+    }
+
+    /**
+     * Adds a medicine usage to the list.
+     * The medicine usage must not overlap with existing medicine usage (with the same name) in the list.
+     */
+    public void add(MedicineUsage toAdd) {
+        requireNonNull(toAdd);
+        if (containsOverlap(toAdd)) {
+            throw new OverlappingMedicineUsageException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the person {@code target} in the list with {@code editedMedicineUsage}.
+     * {@code target} must exist in the list.
+     * The person identity of {@code editedMedicineUsage} must not be the same as another existing person in the list.
+     */
+    public void setMedicineUsage(MedicineUsage target, MedicineUsage editedMedicineUsage) {
+        requireAllNonNull(target, editedMedicineUsage);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new MedicineUsageNotFoundException();
+        }
+
+        if (!target.hasOverlap(editedMedicineUsage) && containsOverlap(editedMedicineUsage)) {
+            throw new OverlappingMedicineUsageException();
+        }
+
+        internalList.set(index, editedMedicineUsage);
+    }
+
+    /**
+     * Removes the equivalent medicine usage from the list.
+     * The medicine usage must exist in the list.
+     */
+    public void remove(MedicineUsage toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new MedicineUsageNotFoundException();
+        }
+    }
+
+    public void setMedicineUsages(MedicineUsageList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code persons}.
+     * {@code persons} must not contain duplicate persons.
+     */
+    public void setMedicineUsages(List<MedicineUsage> medicineUsages) {
+        requireAllNonNull(medicineUsages);
+        if (!medicineUsagesAreUnique(medicineUsages)) {
+            throw new DuplicatePersonException();
+        }
+
+        internalList.setAll(medicineUsages);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<MedicineUsage> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<MedicineUsage> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MedicineUsageList)) {
+            return false;
+        }
+
+        MedicineUsageList otherMedicineUsageList = (MedicineUsageList) other;
+        return internalList.equals(otherMedicineUsageList.internalList);
+    }
+
+    /**
+     * Returns true if {@code medicine usages} contains only unique medicine usages.
+     */
+    private boolean medicineUsagesAreUnique(List<MedicineUsage> medicineUsages) {
+        for (int i = 0; i < medicineUsages.size() - 1; i++) {
+            for (int j = i + 1; j < medicineUsages.size(); j++) {
+                if (medicineUsages.get(i).hasOverlap(medicineUsages.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
@@ -99,6 +99,10 @@ public class MedicineUsageList implements Iterable<MedicineUsage> {
         internalList.setAll(replacement);
     }
 
+    public void reset() {
+        internalList.clear();
+    }
+
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
@@ -1,0 +1,4 @@
+package seedu.address.model.medicineusage;
+
+public class MedicineUsageList {
+}

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsageList.java
@@ -10,7 +10,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.medicineusage.exceptions.MedicineUsageNotFoundException;
 import seedu.address.model.medicineusage.exceptions.OverlappingMedicineUsageException;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 
 /**
@@ -18,11 +17,11 @@ import seedu.address.model.person.exceptions.DuplicatePersonException;
  * A medicine usage is considered unique by comparing using {@code MedicineUsage#hasOverlap(MedicineUsage)}.
  * As such, adding and updating of medicine usages uses MedicineUsage#hasOverlap(MedicineUsage) for equality
  * to ensure that the medicine usage being added or updated is unique in terms of identity in the
- * MedicineUsageList. However, the removal of a person uses MedicineUsage#equals(Object) to ensure that the
+ * MedicineUsageList. However, the removal of a medicine usage uses MedicineUsage#equals(Object) to ensure that the
  * medicine usage with exactly the same fields will be removed.
  * Supports a minimal set of list operations.
  *
- * @see Person#isSamePerson(Person)
+ * @see MedicineUsage#hasOverlap(MedicineUsage)
  */
 public class MedicineUsageList implements Iterable<MedicineUsage> {
     private final ObservableList<MedicineUsage> internalList = FXCollections.observableArrayList();
@@ -50,9 +49,11 @@ public class MedicineUsageList implements Iterable<MedicineUsage> {
     }
 
     /**
-     * Replaces the person {@code target} in the list with {@code editedMedicineUsage}.
+     * Replaces the medicine usage {@code target} in the list with {@code editedMedicineUsage}.
+     * To be used in the future if needed
      * {@code target} must exist in the list.
-     * The person identity of {@code editedMedicineUsage} must not be the same as another existing person in the list.
+     * The medicine usage identity of {@code editedMedicineUsage} must not be the same as another existing
+     * medicine usage in the list.
      */
     public void setMedicineUsage(MedicineUsage target, MedicineUsage editedMedicineUsage) {
         requireAllNonNull(target, editedMedicineUsage);
@@ -89,13 +90,13 @@ public class MedicineUsageList implements Iterable<MedicineUsage> {
      * Replaces the contents of this list with {@code persons}.
      * {@code persons} must not contain duplicate persons.
      */
-    public void setMedicineUsages(List<MedicineUsage> medicineUsages) {
-        requireAllNonNull(medicineUsages);
-        if (!medicineUsagesAreUnique(medicineUsages)) {
+    public void setMedicineUsages(List<MedicineUsage> replacement) {
+        requireAllNonNull(replacement);
+        if (!medicineUsagesAreUnique(replacement)) {
             throw new DuplicatePersonException();
         }
 
-        internalList.setAll(medicineUsages);
+        internalList.setAll(replacement);
     }
 
     /**

--- a/src/main/java/seedu/address/model/medicineusage/exceptions/MedicineUsageNotFoundException.java
+++ b/src/main/java/seedu/address/model/medicineusage/exceptions/MedicineUsageNotFoundException.java
@@ -1,0 +1,7 @@
+package seedu.address.model.medicineusage.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified medicine usage.
+ */
+public class MedicineUsageNotFoundException extends RuntimeException {
+}

--- a/src/main/java/seedu/address/model/medicineusage/exceptions/OverlappingMedicineUsageException.java
+++ b/src/main/java/seedu/address/model/medicineusage/exceptions/OverlappingMedicineUsageException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.medicineusage.exceptions;
+
+/**
+ * Signals that the operation will result in overlapping Medicine Usages (Medicine Usages are considered overlapping
+ * if they have the same name and overlapping startDate, endDate).
+ */
+public class OverlappingMedicineUsageException extends RuntimeException {
+    public OverlappingMedicineUsageException() {
+        super("Operation would result in overlapping medicine usages with the same name");
+    }
+}
+

--- a/src/main/java/seedu/address/model/person/MedicalReport.java
+++ b/src/main/java/seedu/address/model/person/MedicalReport.java
@@ -1,5 +1,8 @@
 package seedu.address.model.person;
 
+import java.util.List;
+
+import javafx.collections.ObservableList;
 import seedu.address.model.medicineusage.MedicineUsage;
 import seedu.address.model.medicineusage.MedicineUsageList;
 
@@ -51,12 +54,20 @@ public class MedicalReport {
         return immunizations;
     }
 
+    public ObservableList<MedicineUsage> getMedicineUsages() {
+        return medicineUsages.asUnmodifiableObservableList();
+    }
+
     public void add(MedicineUsage toAdd) {
         medicineUsages.add(toAdd);
     }
 
     public void remove(MedicineUsage toRemove) {
         medicineUsages.remove(toRemove);
+    }
+
+    public void setMedicineUsages(List<MedicineUsage> newData) {
+        medicineUsages.setMedicineUsages(newData);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/MedicalReport.java
+++ b/src/main/java/seedu/address/model/person/MedicalReport.java
@@ -70,6 +70,10 @@ public class MedicalReport {
         medicineUsages.setMedicineUsages(newData);
     }
 
+    public void reset() {
+        medicineUsages.reset();
+    }
+
     @Override
     public String toString() {
         return (

--- a/src/main/java/seedu/address/model/person/MedicalReport.java
+++ b/src/main/java/seedu/address/model/person/MedicalReport.java
@@ -1,5 +1,8 @@
 package seedu.address.model.person;
 
+import seedu.address.model.medicineusage.MedicineUsage;
+import seedu.address.model.medicineusage.MedicineUsageList;
+
 /**
  * Represents a Person's medical report in the address book.
  */
@@ -13,6 +16,7 @@ public class MedicalReport {
     private final String illnesses;
     private final String surgeries;
     private final String immunizations;
+    private final MedicineUsageList medicineUsages;
 
     /**
      * Constructs a {@code MedicalReport} with the specified medical report details.
@@ -27,6 +31,7 @@ public class MedicalReport {
         this.illnesses = illnesses;
         this.surgeries = surgeries;
         this.immunizations = immunizations;
+        this.medicineUsages = new MedicineUsageList();
         this.value = this.toString();
     }
 
@@ -44,6 +49,14 @@ public class MedicalReport {
 
     public String getImmunizations() {
         return immunizations;
+    }
+
+    public void add(MedicineUsage toAdd) {
+        medicineUsages.add(toAdd);
+    }
+
+    public void remove(MedicineUsage toRemove) {
+        medicineUsages.remove(toRemove);
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedMedicalReport.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMedicalReport.java
@@ -1,10 +1,14 @@
 package seedu.address.storage;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.medicineusage.MedicineUsage;
 import seedu.address.model.person.MedicalReport;
-
 
 
 /**
@@ -17,16 +21,21 @@ class JsonAdaptedMedicalReport {
     private final String illnesses;
     private final String surgeries;
     private final String immunizations;
+    private final List<JsonAdaptedMedicineUsage> medicineUsages = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedMedicalReport} with the given medical report details.
      */
     public JsonAdaptedMedicalReport(@JsonProperty("allergy") String allergy, @JsonProperty("illness") String illness,
-            @JsonProperty("surgery") String surgery, @JsonProperty("immunization") String immunization) {
+            @JsonProperty("surgery") String surgery, @JsonProperty("immunization") String immunization,
+            @JsonProperty("medicineUsages") List<JsonAdaptedMedicineUsage> medicineUsages) {
         this.allergens = allergy;
         this.illnesses = illness;
         this.surgeries = surgery;
         this.immunizations = immunization;
+        if (medicineUsages != null) {
+            this.medicineUsages.addAll(medicineUsages);
+        }
     }
 
     /**
@@ -37,6 +46,8 @@ class JsonAdaptedMedicalReport {
         this.illnesses = source.getIllnesses();
         this.surgeries = source.getSurgeries();
         this.immunizations = source.getImmunizations();
+        this.medicineUsages.addAll(
+                source.getMedicineUsages().stream().map(JsonAdaptedMedicineUsage::new).collect(Collectors.toList()));
     }
 
     /**
@@ -45,6 +56,11 @@ class JsonAdaptedMedicalReport {
      * @throws IllegalValueException if there were any data constraints violated in the adapted medical report.
      */
     public MedicalReport toModelType() throws IllegalValueException {
+        final List<MedicineUsage> personMedicineUsages = new ArrayList<>();
+        for (JsonAdaptedMedicineUsage medicineUsage : this.medicineUsages) {
+            personMedicineUsages.add(medicineUsage.toModelType());
+        }
+
         if (allergens == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "allergy"));
         }
@@ -58,7 +74,10 @@ class JsonAdaptedMedicalReport {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "immunization"));
         }
 
-        return new MedicalReport(allergens, illnesses, surgeries, immunizations);
+        MedicalReport medicalReport = new MedicalReport(allergens, illnesses, surgeries, immunizations);
+        medicalReport.setMedicineUsages(personMedicineUsages);
+
+        return medicalReport;
     }
 }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedMedicineUsage.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMedicineUsage.java
@@ -1,0 +1,76 @@
+package seedu.address.storage;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.DateUtil;
+import seedu.address.model.medicineusage.MedicineUsage;
+
+/**
+ * Jackson-friendly version of {@link MedicineUsage}.
+ */
+public class JsonAdaptedMedicineUsage {
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Medicine Usage's %s field is missing!";
+
+    private final String name;
+    private final String dosage;
+    private final String startDate;
+    private final String endDate;
+
+    /**
+     * Constructs a {@code JsonAdaptedMedicineUsage} with the given medicine usage details.
+     */
+    public JsonAdaptedMedicineUsage(@JsonProperty("name") String name, @JsonProperty("dosage") String dosage,
+                                    @JsonProperty("startDate") String startDate,
+                                    @JsonProperty("endDate") String endDate) {
+        this.name = name;
+        this.dosage = dosage;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    /**
+     * Converts a given {@code MedicineUsage} into this class for Jackson use.
+     */
+    public JsonAdaptedMedicineUsage(MedicineUsage source) {
+        name = source.getName();
+        dosage = source.getDosage();
+        startDate = source.getStringStartDate();
+        endDate = source.getStringEndDate();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted medicine usage object into the model's {@code MedicineUsage} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted medicine usage.
+     */
+    public MedicineUsage toModelType() throws IllegalValueException, DateTimeParseException {
+        if (name == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, "medicine name"));
+        }
+
+        if (dosage == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, "dosage"));
+        }
+
+        if (startDate == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, "start date"));
+        }
+
+        if (endDate == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, "end date"));
+        }
+
+        LocalDate formattedStartDate = LocalDate.parse(startDate, DateUtil.getDisplayDateFormatter());
+        LocalDate formattedEndDate = LocalDate.parse(endDate, DateUtil.getDisplayDateFormatter());
+
+        return new MedicineUsage(name, dosage, formattedStartDate, formattedEndDate);
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -16,6 +16,7 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.medicineusage.exceptions.OverlappingMedicineUsageException;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -187,7 +188,7 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             return commandResult;
-        } catch (CommandException | ParseException e) {
+        } catch (CommandException | ParseException | OverlappingMedicineUsageException e) {
             logger.info("An error occurred while executing command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());
             throw e;

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -10,7 +10,7 @@ import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
 
 /**
- * An UI component that displays information of a {@code Person}.
+ * A UI component that displays information of a {@code Person}.
  */
 public class PersonCard extends UiPart<Region> {
 
@@ -46,6 +46,8 @@ public class PersonCard extends UiPart<Region> {
     private FlowPane tags;
     @FXML
     private Label medicalReport;
+    @FXML
+    private FlowPane medicineUsages;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -63,6 +65,9 @@ public class PersonCard extends UiPart<Region> {
         medicalReport.setText(person.getMedicalReport().value);
         person.getTags().stream().sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        person.getMedicalReport().getMedicineUsages().stream()
+                .forEach(medicineUsage -> medicineUsages.getChildren()
+                        .add(new Label(medicineUsage.toString())));
     }
 }
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -59,6 +59,7 @@
         <Label fx:id="medicalReport" text="\$medicalReport" styleClass="cell_small_label"
           GridPane.rowIndex="5" GridPane.columnIndex="1" />
       </GridPane>
+      <FlowPane fx:id="medicineUsages" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -187,6 +187,12 @@ public class AddCommandTest {
             // Since this is a stub, you can leave it empty or simulate behavior
             throw new UnsupportedOperationException("This method should not be called");
         }
+
+        @Override
+        public void clearMedicineUsage(Person person) {
+            // Since this is a stub, you can leave it empty or simulate behavior
+            throw new UnsupportedOperationException("This method should not be called");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.Klinix;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyKlinix;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.medicineusage.MedicineUsage;
 import seedu.address.model.person.MedicalReport;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
@@ -173,6 +174,18 @@ public class AddCommandTest {
         @Override
         public void deleteMedicalReport(Person person) {
             throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addMedicineUsage(Person person, MedicineUsage medicineUsage) {
+            // Since this is a stub, you can leave it empty or simulate behavior
+            throw new UnsupportedOperationException("This method should not be called");
+        }
+
+        @Override
+        public void deleteMedicineUsage(Person person, MedicineUsage medicineUsage) {
+            // Since this is a stub, you can leave it empty or simulate behavior
+            throw new UnsupportedOperationException("This method should not be called");
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddMedicineUsageCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMedicineUsageCommandTest.java
@@ -1,0 +1,99 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.ModelManager;
+import seedu.address.model.medicineusage.MedicineUsage;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.BirthDate;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.MedicalReport;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+class AddMedicineUsageCommandTest {
+    private ModelManager model;
+    private Person person;
+    private Nric nric;
+    private MedicineUsage medicineUsage;
+
+    @BeforeEach
+    void setUp() {
+        model = new ModelManager();
+        nric = new Nric("S1234567A");
+        person = new Person(
+                new Name("John Doe"),
+                new Phone("12345678"),
+                new Email("john@example.com"),
+                nric,
+                new BirthDate("01/01/1990"),
+                new Address("123 Street"),
+                new HashSet<Tag>(),
+                new MedicalReport("None", "None", "None", "None")
+        );
+        medicineUsage = new MedicineUsage("Paracetamol", "500mg", LocalDate.now(), LocalDate.now().plusDays(5));
+        model.addPerson(person);
+    }
+
+    @Test
+    void execute_success() {
+        AddMedicineUsageCommand command = new AddMedicineUsageCommand(nric, medicineUsage);
+        assertDoesNotThrow(() -> command.execute(model));
+        assertTrue(person.getMedicalReport().getMedicineUsages().contains(medicineUsage));
+    }
+
+    @Test
+    void execute_personNotFound_throwsCommandException() {
+        Nric nonExistentNric = new Nric("S9999999Z");
+        AddMedicineUsageCommand command = new AddMedicineUsageCommand(nonExistentNric, medicineUsage);
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    @Test
+    void equals_sameObject_returnsTrue() {
+        AddMedicineUsageCommand command = new AddMedicineUsageCommand(nric, medicineUsage);
+        assertTrue(command.equals(command));
+    }
+
+    @Test
+    void equals_differentObjectWithSameValues_returnsTrue() {
+        AddMedicineUsageCommand command1 = new AddMedicineUsageCommand(nric, medicineUsage);
+        AddMedicineUsageCommand command2 = new AddMedicineUsageCommand(nric, medicineUsage);
+        assertTrue(command1.equals(command2));
+    }
+
+    @Test
+    void equals_differentObject_returnsFalse() {
+        AddMedicineUsageCommand command = new AddMedicineUsageCommand(nric, medicineUsage);
+        assertFalse(command.equals(new Object()));
+    }
+
+    @Test
+    void equals_differentNric_returnsFalse() {
+        AddMedicineUsageCommand command1 = new AddMedicineUsageCommand(new Nric("S7654321B"), medicineUsage);
+        AddMedicineUsageCommand command2 = new AddMedicineUsageCommand(nric, medicineUsage);
+        assertFalse(command1.equals(command2));
+    }
+
+    @Test
+    void equals_differentMedicineUsage_returnsFalse() {
+        MedicineUsage differentMedicineUsage = new MedicineUsage("Ibuprofen", "200mg", LocalDate.now(),
+                LocalDate.now().plusDays(5));
+        AddMedicineUsageCommand command1 = new AddMedicineUsageCommand(nric, differentMedicineUsage);
+        AddMedicineUsageCommand command2 = new AddMedicineUsageCommand(nric, medicineUsage);
+        assertFalse(command1.equals(command2));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ClearMedicineUsageCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearMedicineUsageCommandTest.java
@@ -1,0 +1,91 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.ModelManager;
+import seedu.address.model.medicineusage.MedicineUsage;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.BirthDate;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.MedicalReport;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+
+class ClearMedicineUsageCommandTest {
+    private ModelManager model;
+    private Person person;
+    private Nric nric;
+    private MedicineUsage medicineUsage;
+
+    @BeforeEach
+    void setUp() {
+        model = new ModelManager();
+        nric = new Nric("S1234567A");
+        person = new Person(
+                new Name("John Doe"),
+                new Phone("12345678"),
+                new Email("john@example.com"),
+                nric,
+                new BirthDate("01/01/1990"),
+                new Address("123 Street"),
+                new HashSet<>(),
+                new MedicalReport("None", "None", "None", "None")
+        );
+        medicineUsage = new MedicineUsage("Paracetamol", "500mg", LocalDate.now(), LocalDate.now().plusDays(5));
+        person.getMedicalReport().add(medicineUsage);
+        model.addPerson(person);
+    }
+
+    @Test
+    void execute_success() {
+        ClearMedicineUsageCommand command = new ClearMedicineUsageCommand(nric);
+        assertDoesNotThrow(() -> command.execute(model));
+        assertTrue(person.getMedicalReport().getMedicineUsages().isEmpty());
+    }
+
+    @Test
+    void execute_personNotFound_throwsCommandException() {
+        Nric nonExistentNric = new Nric("S9999999Z");
+        ClearMedicineUsageCommand command = new ClearMedicineUsageCommand(nonExistentNric);
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    @Test
+    void equals_sameObject_returnsTrue() {
+        ClearMedicineUsageCommand command = new ClearMedicineUsageCommand(nric);
+        assertTrue(command.equals(command));
+    }
+
+    @Test
+    void equals_differentObjectWithSameValues_returnsTrue() {
+        ClearMedicineUsageCommand command1 = new ClearMedicineUsageCommand(nric);
+        ClearMedicineUsageCommand command2 = new ClearMedicineUsageCommand(nric);
+        assertTrue(command1.equals(command2));
+    }
+
+    @Test
+    void equals_differentObject_returnsFalse() {
+        ClearMedicineUsageCommand command = new ClearMedicineUsageCommand(nric);
+        assertFalse(command.equals(new Object()));
+    }
+
+    @Test
+    void equals_differentNric_returnsFalse() {
+        ClearMedicineUsageCommand command1 = new ClearMedicineUsageCommand(new Nric("S7654321B"));
+        ClearMedicineUsageCommand command2 = new ClearMedicineUsageCommand(nric);
+        assertFalse(command1.equals(command2));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ClearMedicineUsageCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearMedicineUsageCommandTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;

--- a/src/test/java/seedu/address/logic/parser/AddMedicineUsageCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMedicineUsageCommandParserTest.java
@@ -1,0 +1,68 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddMedicineUsageCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.medicineusage.MedicineUsage;
+import seedu.address.model.person.Nric;
+
+class AddMedicineUsageCommandParserTest {
+    private AddMedicineUsageCommandParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new AddMedicineUsageCommandParser();
+    }
+
+    @Test
+    void parse_validInput_success() throws ParseException {
+        String input = " ic/S1234567A n/Paracetamol dos/500mg from/01-01-2025 to/05-01-2025";
+        AddMedicineUsageCommand command = parser.parse(input);
+        assertNotNull(command);
+    }
+
+    @Test
+    void parse_invalidDateFormat_throwsParseException() {
+        String input = " ic/S1234567A n/Paracetamol dos/500mg from/2025-01-01 to/2025-01-05";
+        assertThrows(DateTimeParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void arePrefixesPresent_allPrefixesPresent_returnsTrue() throws ParseException {
+        String input = " ic/S1234567A n/Paracetamol dos/500mg from/01-01-2025 to/05-01-2025";
+        AddMedicineUsageCommand command = parser.parse(input);
+        assertNotNull(command);
+    }
+
+    @Test
+    void arePrefixesPresent_missingPrefixes_returnsFalse() {
+        String input = " n/Paracetamol dos/500mg from/01-01-2025 to/05-01-2025";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_duplicatePrefixes_throwsParseException() {
+        String input = " ic/S1234567A n/Paracetamol n/Ibuprofen dos/500mg from/01-01-2025 to/05-01-2025";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_correctValues_parsedCorrectly() throws ParseException {
+        String input = " ic/S1234567A n/Paracetamol dos/500mg from/01-01-2025 to/05-01-2025";
+        AddMedicineUsageCommand command = parser.parse(input);
+        Nric expectedNric = new Nric("S1234567A");
+        MedicineUsage expectedMedicineUsage = new MedicineUsage("Paracetamol", "500mg",
+                LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 5));
+        assertEquals(new AddMedicineUsageCommand(expectedNric, expectedMedicineUsage), command);
+    }
+}
+

--- a/src/test/java/seedu/address/logic/parser/ClearMedicineUsageCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClearMedicineUsageCommandParserTest.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ClearMedicineUsageCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Nric;
+
+class ClearMedicineUsageCommandParserTest {
+    private ClearMedicineUsageCommandParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new ClearMedicineUsageCommandParser();
+    }
+
+    @Test
+    void parse_validInput_success() throws ParseException {
+        String input = " ic/S1234567A";
+        ClearMedicineUsageCommand command = parser.parse(input);
+        assertNotNull(command);
+    }
+
+    @Test
+    void parse_missingRequiredField_throwsParseException() {
+        String input = " ";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_invalidNricFormat_throwsParseException() {
+        String input = " ic/INVALID123";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_correctValues_parsedCorrectly() throws ParseException {
+        String input = " ic/S1234567A";
+        ClearMedicineUsageCommand command = parser.parse(input);
+        Nric expectedNric = new Nric("S1234567A");
+        assertEquals(new ClearMedicineUsageCommand(expectedNric), command);
+    }
+}
+

--- a/src/test/java/seedu/address/logic/parser/KlinixParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/KlinixParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,7 +15,9 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddMedicineUsageCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearMedicineUsageCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
@@ -23,7 +26,9 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.medicineusage.MedicineUsage;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -97,5 +102,40 @@ public class KlinixParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+    }
+    @Test
+    void parseCommand_addMedicineUsage_success() throws Exception {
+        String input = "addmu ic/S1234567A n/Paracetamol dos/500mg from/01-01-2025 to/05-01-2025";
+        AddMedicineUsageCommand command = (AddMedicineUsageCommand) parser.parseCommand(input);
+        Nric expectedNric = new Nric("S1234567A");
+        MedicineUsage expectedMedicineUsage = new MedicineUsage("Paracetamol", "500mg",
+                LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 5));
+        assertEquals(new AddMedicineUsageCommand(expectedNric, expectedMedicineUsage), command);
+    }
+
+    @Test
+    void parseCommand_clearMedicineUsage_success() throws Exception {
+        String input = "clearmu ic/S1234567A";
+        ClearMedicineUsageCommand command = (ClearMedicineUsageCommand) parser.parseCommand(input);
+        Nric expectedNric = new Nric("S1234567A");
+        assertEquals(new ClearMedicineUsageCommand(expectedNric), command);
+    }
+
+    @Test
+    void parseCommand_clearMedicineUsageInvalidInput_throwsParseException() {
+        String input = "clearmu";
+        assertThrows(ParseException.class, () -> parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_addMedicineUsageUnrecognizedCommand_throwsParseException() {
+        String input = "addmed ic/S1234567A n/Paracetamol dos/500mg from/01-01-2025 to/05-01-2025";
+        assertThrows(ParseException.class, () -> parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_clearMedicineUsageUnrecognizedCommand_throwsParseException() {
+        String input = "clearmeds ic/S1234567A";
+        assertThrows(ParseException.class, () -> parser.parseCommand(input));
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -10,11 +10,13 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDate;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.medicineusage.MedicineUsage;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.KlinixBuilder;
 
@@ -128,5 +130,26 @@ public class ModelManagerTest {
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setKlinixFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
+    }
+
+    @Test
+    void addMedicineUsage_personExists_success() {
+        ModelManager modelManager = new ModelManager();
+        modelManager.addPerson(ALICE);
+        MedicineUsage medicineUsage = new MedicineUsage("Paracetamol", "500mg",
+                LocalDate.now(), LocalDate.now().plusDays(5));
+        modelManager.addMedicineUsage(ALICE, medicineUsage);
+        assertTrue(ALICE.getMedicalReport().getMedicineUsages().contains(medicineUsage));
+    }
+
+    @Test
+    void clearMedicineUsage_personExists_success() {
+        ModelManager modelManager = new ModelManager();
+        modelManager.addPerson(ALICE);
+        MedicineUsage medicineUsage = new MedicineUsage("Panadol", "500mg",
+                LocalDate.now(), LocalDate.now().plusDays(5));
+        modelManager.addMedicineUsage(ALICE, medicineUsage);
+        modelManager.clearMedicineUsage(ALICE);
+        assertTrue(ALICE.getMedicalReport().getMedicineUsages().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/model/medicineusage/MedicineUsageListTest.java
+++ b/src/test/java/seedu/address/model/medicineusage/MedicineUsageListTest.java
@@ -1,0 +1,91 @@
+package seedu.address.model.medicineusage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.medicineusage.exceptions.MedicineUsageNotFoundException;
+import seedu.address.model.medicineusage.exceptions.OverlappingMedicineUsageException;
+
+class MedicineUsageListTest {
+    private MedicineUsageList medicineUsageList;
+    private MedicineUsage medicineUsage1;
+    private MedicineUsage medicineUsage2;
+    private MedicineUsage overlappingMedicineUsage;
+
+    @BeforeEach
+    void setUp() {
+        medicineUsageList = new MedicineUsageList();
+        medicineUsage1 = new MedicineUsage("Paracetamol", "500mg", LocalDate.now(),
+                LocalDate.now().plusDays(5));
+        medicineUsage2 = new MedicineUsage("Ibuprofen", "200mg", LocalDate.now().plusDays(6),
+                LocalDate.now().plusDays(10));
+        overlappingMedicineUsage = new MedicineUsage("Paracetamol", "500mg",
+                LocalDate.now().plusDays(2), LocalDate.now().plusDays(7));
+    }
+
+    @Test
+    void add_uniqueMedicineUsage_success() {
+        medicineUsageList.add(medicineUsage1);
+        assertTrue(medicineUsageList.asUnmodifiableObservableList().contains(medicineUsage1));
+    }
+
+    @Test
+    void add_overlappingMedicineUsage_throwsException() {
+        medicineUsageList.add(medicineUsage1);
+        assertThrows(OverlappingMedicineUsageException.class, () -> medicineUsageList.add(overlappingMedicineUsage));
+    }
+
+    @Test
+    void remove_existingMedicineUsage_success() {
+        medicineUsageList.add(medicineUsage1);
+        medicineUsageList.remove(medicineUsage1);
+        assertFalse(medicineUsageList.asUnmodifiableObservableList().contains(medicineUsage1));
+    }
+
+    @Test
+    void remove_nonExistingMedicineUsage_throwsException() {
+        assertThrows(MedicineUsageNotFoundException.class, () -> medicineUsageList.remove(medicineUsage1));
+    }
+
+    @Test
+    void setMedicineUsages_validList_success() {
+        List<MedicineUsage> newUsages = Arrays.asList(medicineUsage1, medicineUsage2);
+        medicineUsageList.setMedicineUsages(newUsages);
+        assertEquals(newUsages.size(), medicineUsageList.asUnmodifiableObservableList().size());
+    }
+
+    @Test
+    void setMedicineUsages_listWithOverlappingEntries_throwsException() {
+        List<MedicineUsage> newUsages = Arrays.asList(medicineUsage1, overlappingMedicineUsage);
+        assertThrows(OverlappingMedicineUsageException.class, () -> medicineUsageList.setMedicineUsages(newUsages));
+    }
+
+    @Test
+    void reset_clearsAllMedicineUsages() {
+        medicineUsageList.add(medicineUsage1);
+        medicineUsageList.add(medicineUsage2);
+        medicineUsageList.reset();
+        assertTrue(medicineUsageList.asUnmodifiableObservableList().isEmpty());
+    }
+
+    @Test
+    void containsOverlap_medicineUsageWithOverlap_returnsTrue() {
+        medicineUsageList.add(medicineUsage1);
+        assertTrue(medicineUsageList.containsOverlap(overlappingMedicineUsage));
+    }
+
+    @Test
+    void containsOverlap_noOverlap_returnsFalse() {
+        medicineUsageList.add(medicineUsage1);
+        assertFalse(medicineUsageList.containsOverlap(medicineUsage2));
+    }
+}

--- a/src/test/java/seedu/address/model/medicineusage/MedicineUsageTest.java
+++ b/src/test/java/seedu/address/model/medicineusage/MedicineUsageTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,87 +13,86 @@ public class MedicineUsageTest {
 
     @Test
     public void constructor_nullParameters_throwsNullPointerException() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate today = LocalDate.now();
         // Test each parameter being null; all should throw NullPointerException
         assertThrows(NullPointerException.class, () ->
-                new MedicineUsage(null, "2 pills", now, now.plusDays(1)));
+                new MedicineUsage(null, "2 pills", today, today.plusDays(1)));
         assertThrows(NullPointerException.class, () ->
-                new MedicineUsage("Panadol", null, now, now.plusDays(1)));
+                new MedicineUsage("Panadol", null, today, today.plusDays(1)));
         assertThrows(NullPointerException.class, () ->
-                new MedicineUsage("Panadol", "2 pills", null, now.plusDays(1)));
+                new MedicineUsage("Panadol", "2 pills", null, today.plusDays(1)));
         assertThrows(NullPointerException.class, () ->
-                new MedicineUsage("Panadol", "2 pills", now, null));
+                new MedicineUsage("Panadol", "2 pills", today, null));
     }
 
     @Test
     public void constructor_validParameters_success() {
-        LocalDateTime now = LocalDateTime.now();
-        MedicineUsage medicineUsage = new MedicineUsage("Panadol", "2 pills", now, now.plusDays(1));
+        LocalDate today = LocalDate.now();
+        MedicineUsage medicineUsage = new MedicineUsage("Panadol", "2 pills", today, today.plusDays(1));
 
         // Test that the object was created correctly
         assertEquals("Panadol", medicineUsage.getName());
         assertEquals("2 pills", medicineUsage.getDosage());
-        assertEquals(now, medicineUsage.getStartDate());
-        assertEquals(now.plusDays(1), medicineUsage.getEndDate());
+        assertEquals(today, medicineUsage.getStartDate());
+        assertEquals(today.plusDays(1), medicineUsage.getEndDate());
     }
 
     @Test
     public void equals_sameObject_returnsTrue() {
-        LocalDateTime now = LocalDateTime.now();
-        MedicineUsage medicineUsage = new MedicineUsage("Panadol", "2 pills", now, now.plusDays(1));
+        LocalDate today = LocalDate.now();
+        MedicineUsage medicineUsage = new MedicineUsage("Panadol", "2 pills", today, today.plusDays(1));
         // Checking reflexivity
         assertTrue(medicineUsage.equals(medicineUsage));
     }
 
     @Test
     public void equals_sameNameOverlappingDates_returnsTrue() {
-        LocalDateTime now = LocalDateTime.now();
-        // First usage: starts now, ends after 1 day
-        MedicineUsage usageA = new MedicineUsage("Panadol", "2 pills", now, now.plusDays(1));
-        // Second usage: same name, overlapping the same time range
-        // Overlaps from now until it ends after half a day
-        MedicineUsage usageB = new MedicineUsage("Panadol", "2 pills", now.plusHours(12), now.plusDays(1));
+        LocalDate today = LocalDate.now();
+        // First usage: starts today, ends after 1 day
+        MedicineUsage usageA = new MedicineUsage("Panadol", "2 pills", today, today.plusDays(1));
+        // Second usage: same name, overlapping (starts within the first usage's period)
+        MedicineUsage usageB = new MedicineUsage("Panadol", "2 pills", today.plusDays(1), today.plusDays(2));
 
-        // Should be true, because name is the same and the date ranges overlap
-        assertTrue(usageA.equals(usageB));
+        // Should be true because name is the same and the date ranges overlap
+        assertTrue(usageA.hasOverlap(usageB));
     }
 
     @Test
     public void equals_sameNameNoOverlap_returnsFalse() {
-        LocalDateTime now = LocalDateTime.now();
-        // usageA: from now until tomorrow
-        MedicineUsage usageA = new MedicineUsage("Panadol", "2 pills", now, now.plusDays(1));
+        LocalDate today = LocalDate.now();
+        // usageA: from today until tomorrow
+        MedicineUsage usageA = new MedicineUsage("Panadol", "2 pills", today, today.plusDays(1));
         // usageB: starts the day after usageA ends
         MedicineUsage usageB = new MedicineUsage("Panadol", "2 pills",
-                now.plusDays(2), now.plusDays(3));
+                today.plusDays(2), today.plusDays(3));
 
-        // Should be false, because the date ranges do not overlap
-        assertFalse(usageA.equals(usageB));
+        // Should be false because the date ranges do not overlap
+        assertFalse(usageA.hasOverlap(usageB));
     }
 
     @Test
     public void equals_differentName_returnsFalse() {
-        LocalDateTime now = LocalDateTime.now();
-        MedicineUsage usageA = new MedicineUsage("Panadol", "2 pills", now, now.plusDays(1));
+        LocalDate today = LocalDate.now();
+        MedicineUsage usageA = new MedicineUsage("Panadol", "2 pills", today, today.plusDays(1));
         // Different name, same date range
-        MedicineUsage usageB = new MedicineUsage("Tylenol", "2 pills", now, now.plusDays(1));
+        MedicineUsage usageB = new MedicineUsage("Tylenol", "2 pills", today, today.plusDays(1));
 
-        // Should be false, because the names are different
+        // Should be false because the names are different
         assertFalse(usageA.equals(usageB));
     }
 
     @Test
     public void equals_nullObject_returnsFalse() {
-        LocalDateTime now = LocalDateTime.now();
-        MedicineUsage medicineUsage = new MedicineUsage("Panadol", "2 pills", now, now.plusDays(1));
+        LocalDate today = LocalDate.now();
+        MedicineUsage medicineUsage = new MedicineUsage("Panadol", "2 pills", today, today.plusDays(1));
         // Comparing with null should always return false
         assertFalse(medicineUsage.equals(null));
     }
 
     @Test
     public void equals_differentObjectType_returnsFalse() {
-        LocalDateTime now = LocalDateTime.now();
-        MedicineUsage medicineUsage = new MedicineUsage("Panadol", "2 pills", now, now.plusDays(1));
+        LocalDate today = LocalDate.now();
+        MedicineUsage medicineUsage = new MedicineUsage("Panadol", "2 pills", today, today.plusDays(1));
         // Compare with a completely different object type
         assertFalse(medicineUsage.equals("Some string"));
     }


### PR DESCRIPTION
Things to note:
- `MedicineUsage` is included as an `ObservableList` inside `MedicalReport`. Structure is the same as the list of `Person`s stored in `UniquePersonList`, this helps if we want to implement filters on `MedicineUsage` in the future (e.g filter by date, name, ...)
- The UI display of `MedicineUsage` is only temporary and requires another PR to implement @mervyn-teo 
- Some test cases are added
- Implementation of `DeleteMedicineUsage` is delayed until the UI is implemented (if delete by index, or by id, then the user first should be able to see these indices/ids). Instead `ClearMedicineUsage` is implemented to delete all `MedicineUsage` of a `Person` by `Nric` (This is sufficient for MVP)

Things to check:
- Check if the logic for `MedicineUsageList` makes sense/neccessary.
- Check the new methods in `ModelManager`.
- Check the comment headers (I did a lot of copy and paste for comments, so might forget to change some names)
- Check the storage code updates

Resolves #42 