### PR TITLE
Add find medicine by name functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindMedicineUsageCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindMedicineUsageCommand.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.MedicineUsageContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all medicine usages in the Klinix whose name contains any of the argument keywords.
+ * Keywords matching is case-insensitive.
+ * Matching medicine usages are displayed as a list of person containing them.
+ */
+public class FindMedicineUsageCommand extends Command {
+
+    public static final String COMMAND_WORD = "findmu";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all medicine usages whose names contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list of persons (users) "
+            + "with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " paracetamol amoxicillin";
+
+    private final MedicineUsageContainsKeywordsPredicate predicate;
+
+    public FindMedicineUsageCommand(MedicineUsageContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FindMedicineUsageCommand)) {
+            return false;
+        }
+
+        FindMedicineUsageCommand otherFindMedicineUsageCommand = (FindMedicineUsageCommand) other;
+        return predicate.equals(otherFindMedicineUsageCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/FindMedicineUsageCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindMedicineUsageCommandParser.java
@@ -9,13 +9,13 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.MedicineUsageContainsKeywordsPredicate;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new FindMedicineUsageCommand object
  */
 public class FindMedicineUsageCommandParser implements Parser<FindMedicineUsageCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the FindCommand
-     * and returns a FindCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the FindMedicineUsageCommand
+     * and returns a FindMedicineUsageCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindMedicineUsageCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/FindMedicineUsageCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindMedicineUsageCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.FindMedicineUsageCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.MedicineUsageContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FindCommand object
+ */
+public class FindMedicineUsageCommandParser implements Parser<FindMedicineUsageCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindMedicineUsageCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindMedicineUsageCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FindMedicineUsageCommand(new MedicineUsageContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/KlinixParser.java
+++ b/src/main/java/seedu/address/logic/parser/KlinixParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.DeleteMedicalReportCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindMedicineUsageCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -93,6 +94,9 @@ public class KlinixParser {
 
         case ClearMedicineUsageCommand.COMMAND_WORD:
             return new ClearMedicineUsageCommandParser().parse(arguments);
+
+        case FindMedicineUsageCommand.COMMAND_WORD:
+            return new FindMedicineUsageCommandParser().parse(arguments);
 
         case AddAppointmentCommand.COMMAND_WORD:
             return new AddAppointmentCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/KlinixParser.java
+++ b/src/main/java/seedu/address/logic/parser/KlinixParser.java
@@ -98,7 +98,7 @@ public class KlinixParser {
 
         case FindMedicineUsageCommand.COMMAND_WORD:
             return new FindMedicineUsageCommandParser().parse(arguments);
-            
+
         case DeleteMedicineUsageCommand.COMMAND_WORD:
             return new DeleteMedicineUsageCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/model/person/MedicineUsageContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/MedicineUsageContainsKeywordsPredicate.java
@@ -1,0 +1,47 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Medicine Usage}s matches any of the keywords given.
+ */
+public class MedicineUsageContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public MedicineUsageContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        List<String> medicineNames = person.getMedicineUsageNames();
+        return keywords.stream().anyMatch(keyword ->
+                medicineNames.stream().anyMatch(name ->
+                        StringUtil.containsWordIgnoreCase(name, keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MedicineUsageContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        MedicineUsageContainsKeywordsPredicate otherMedicineUsageContainsKeywordsPredicate =
+                (MedicineUsageContainsKeywordsPredicate) other;
+        return keywords.equals(otherMedicineUsageContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -8,9 +8,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentList;
+import seedu.address.model.medicineusage.MedicineUsage;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -93,6 +95,20 @@ public class Person {
      */
     public MedicalReport getMedicalReport() {
         return medicalReport;
+    }
+
+    public ObservableList<MedicineUsage> getMedicineUsages() {
+        return medicalReport.getMedicineUsages();
+    }
+
+    public void deleteMedicineUsage(MedicineUsage medicineUsage) {
+        medicalReport.remove(medicineUsage);
+    }
+
+    public List<String> getMedicineUsageNames() {
+        return getMedicineUsages().stream()
+                .map(MedicineUsage::getName)
+                .toList();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FindMedicineUsageCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindMedicineUsageCommandTest.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Klinix;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.MedicineUsageContainsKeywordsPredicate;
+import seedu.address.testutil.PersonBuilder;
+
+public class FindMedicineUsageCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(new Klinix(), new UserPrefs());
+        expectedModel = new ModelManager(new Klinix(), new UserPrefs());
+
+        model.addPerson(new PersonBuilder().withName("Alice").build());
+        expectedModel.addPerson(new PersonBuilder().withName("Alice").build());
+    }
+
+    @Test
+    public void execute_zeroKeywords_noMatch() {
+        MedicineUsageContainsKeywordsPredicate predicate =
+                new MedicineUsageContainsKeywordsPredicate(Collections.singletonList("paracetamol"));
+        FindMedicineUsageCommand command = new FindMedicineUsageCommand(predicate);
+
+        expectedModel.updateFilteredPersonList(predicate);
+
+        CommandResult result = command.execute(model);
+
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+        assertEquals(String.format("%d persons listed!", model.getFilteredPersonList().size()),
+                result.getFeedbackToUser());
+    }
+
+    @Test
+    public void equals() {
+        MedicineUsageContainsKeywordsPredicate firstPredicate =
+                new MedicineUsageContainsKeywordsPredicate(Collections.singletonList("paracetamol"));
+        MedicineUsageContainsKeywordsPredicate secondPredicate =
+                new MedicineUsageContainsKeywordsPredicate(Collections.singletonList("ibuprofen"));
+
+        FindMedicineUsageCommand firstCommand = new FindMedicineUsageCommand(firstPredicate);
+        FindMedicineUsageCommand secondCommand = new FindMedicineUsageCommand(secondPredicate);
+
+        assertEquals(firstCommand, new FindMedicineUsageCommand(firstPredicate));
+        assertNotEquals(null, firstCommand);
+        assertNotEquals(firstCommand, secondCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindMedicineUsageCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindMedicineUsageCommandParserTest.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindMedicineUsageCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.MedicineUsageContainsKeywordsPredicate;
+
+public class FindMedicineUsageCommandParserTest {
+
+    private final FindMedicineUsageCommandParser parser = new FindMedicineUsageCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() throws ParseException {
+        FindMedicineUsageCommand expectedCommand =
+                new FindMedicineUsageCommand(new MedicineUsageContainsKeywordsPredicate(
+                        Arrays.asList("paracetamol", "amoxicillin")));
+
+        assertEquals(expectedCommand, parser.parse("paracetamol amoxicillin"));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("   "));
+    }
+}

--- a/src/test/java/seedu/address/model/person/MedicineUsageContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/MedicineUsageContainsKeywordsPredicateTest.java
@@ -1,0 +1,86 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.medicineusage.MedicineUsage;
+import seedu.address.testutil.PersonBuilder;
+
+public class MedicineUsageContainsKeywordsPredicateTest {
+
+    @Test
+    public void test_medicineNameContainsKeyword_returnsTrue() {
+        MedicineUsage med = new MedicineUsage("Paracetamol", "2 pills",
+                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 10));
+        MedicalReport report = new MedicalReport("", "", "", "");
+        report.add(med);
+
+        Person person = new PersonBuilder()
+                .withMedicalReport(report)
+                .build();
+
+        MedicineUsageContainsKeywordsPredicate predicate =
+                new MedicineUsageContainsKeywordsPredicate(Collections.singletonList("paracetamol"));
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
+    public void test_medicineNameDoesNotMatch_returnsFalse() {
+        MedicineUsage med = new MedicineUsage("Ibuprofen", "1 tablet",
+                LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 5));
+        MedicalReport report = new MedicalReport("", "", "", "");
+        report.add(med);
+
+        Person person = new PersonBuilder()
+                .withMedicalReport(report)
+                .build();
+
+        MedicineUsageContainsKeywordsPredicate predicate =
+                new MedicineUsageContainsKeywordsPredicate(Collections.singletonList("paracetamol"));
+        assertFalse(predicate.test(person));
+    }
+
+    @Test
+    public void test_multipleKeywords_oneMatch() {
+        MedicineUsage med = new MedicineUsage("Ibuprofen", "1 tablet",
+                LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 5));
+        MedicalReport report = new MedicalReport("", "", "", "");
+        report.add(med);
+
+        Person person = new PersonBuilder()
+                .withMedicalReport(report)
+                .build();
+
+        List<String> keywords = Arrays.asList("paracetamol", "ibuprofen");
+        MedicineUsageContainsKeywordsPredicate predicate =
+                new MedicineUsageContainsKeywordsPredicate(keywords);
+
+        assertTrue(predicate.test(person));
+    }
+
+    @Test
+    public void test_equals() {
+        List<String> firstKeywords = Collections.singletonList("panadol");
+        List<String> secondKeywords = Collections.singletonList("amoxicillin");
+
+        MedicineUsageContainsKeywordsPredicate firstPredicate =
+                new MedicineUsageContainsKeywordsPredicate(firstKeywords);
+        MedicineUsageContainsKeywordsPredicate secondPredicate =
+                new MedicineUsageContainsKeywordsPredicate(secondKeywords);
+
+        assertEquals(firstPredicate, new MedicineUsageContainsKeywordsPredicate(firstKeywords)); // same value
+        assertNotEquals(firstPredicate, secondPredicate); // different keywords
+        assertNotEquals(null, firstPredicate);
+        assertNotEquals("some string", firstPredicate);
+    }
+}
+


### PR DESCRIPTION
Things to note:
- Command format: `findmu [KEYWORD] [KEYWORD] ...`
- Behavior should be the same as `find` command
- Added some (bare minimum) test cases