### PR TITLE
Add JsonAdaptedAppointmentTest.java

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
@@ -70,5 +70,15 @@ public class JsonAdaptedAppointment {
 
         return new Appointment(doctorNric, appointmentDescription, startDate, endDate);
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof JsonAdaptedAppointment // instanceof handles nulls
+                && doctorNric.equals(((JsonAdaptedAppointment) other).doctorNric)
+                && appointmentDescription.equals(((JsonAdaptedAppointment) other).appointmentDescription)
+                && startDate.equals(((JsonAdaptedAppointment) other).startDate)
+                && endDate.equals(((JsonAdaptedAppointment) other).endDate));
+    }
 }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
@@ -13,8 +13,8 @@ public class JsonAdaptedAppointmentTest {
 
     private static final String VALID_DOCTOR_NRIC = "S1234567A";
     private static final String VALID_APPOINTMENT_DESCRIPTION = "Dental Checkup";
-    private static final String VALID_START_DATE = LocalDate.of(2020, 1, 1).toString();
-    private static final String VALID_END_DATE = LocalDate.of(2020, 1, 10).toString();
+    private static final LocalDate VALID_START_DATE = LocalDate.of(2020, 1, 1);
+    private static final LocalDate VALID_END_DATE = LocalDate.of(2020, 1, 10);
 
     /**
      * Ensures that the JsonAdaptedAppointment correctly converts a valid Appointment object into a JsonAdaptedAppointment
@@ -22,7 +22,7 @@ public class JsonAdaptedAppointmentTest {
     @Test
     public void toModelType_validAppointmentDetails_returnsAppointment() throws Exception {
         Appointment originalAppointment = new Appointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
-                LocalDate.parse(VALID_START_DATE), LocalDate.parse(VALID_END_DATE));
+                VALID_START_DATE, VALID_END_DATE);
         JsonAdaptedAppointment adaptedAppointment = new JsonAdaptedAppointment(originalAppointment);
         assertEquals(originalAppointment, adaptedAppointment.toModelType());
     }
@@ -30,7 +30,7 @@ public class JsonAdaptedAppointmentTest {
     @Test
     public void toModelType_nullDoctorNric_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(null, VALID_APPOINTMENT_DESCRIPTION,
-                LocalDate.parse(VALID_START_DATE), LocalDate.parse(VALID_END_DATE));
+                VALID_START_DATE, VALID_END_DATE);
         String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
                                                "doctor nric should not be null");
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
@@ -39,7 +39,7 @@ public class JsonAdaptedAppointmentTest {
     @Test
     public void toModelType_nullAppointmentDescription_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, null,
-                LocalDate.parse(VALID_START_DATE), LocalDate.parse(VALID_END_DATE));
+                VALID_START_DATE, VALID_END_DATE);
         String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
                 "appointment description should not be null");
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
@@ -48,7 +48,7 @@ public class JsonAdaptedAppointmentTest {
     @Test
     public void toModelType_nullStartDate_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
-                null, LocalDate.parse(VALID_END_DATE));
+                null, VALID_END_DATE);
         String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
                 "start date should not be null");
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
@@ -57,7 +57,7 @@ public class JsonAdaptedAppointmentTest {
     @Test
     public void toModelType_nullEndDate_throwsIllegalValueException() {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
-                LocalDate.parse(VALID_START_DATE), null);
+                VALID_START_DATE, null);
         String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
                 "end date should not be null");
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);

--- a/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
@@ -21,10 +21,12 @@ public class JsonAdaptedAppointmentTest {
      */
     @Test
     public void toModelType_validAppointmentDetails_returnsAppointment() throws Exception {
-        Appointment originalAppointment = new Appointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
+        Appointment expectedAppointment = new Appointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
                 VALID_START_DATE, VALID_END_DATE);
-        JsonAdaptedAppointment adaptedAppointment = new JsonAdaptedAppointment(originalAppointment);
-        assertEquals(originalAppointment, adaptedAppointment.toModelType());
+        JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
+                VALID_START_DATE, VALID_END_DATE);
+
+        assertEquals(expectedAppointment, appointment.toModelType());
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
@@ -32,7 +32,7 @@ public class JsonAdaptedAppointmentTest {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(null, VALID_APPOINTMENT_DESCRIPTION,
                 VALID_START_DATE, VALID_END_DATE);
         String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
-                                               "doctor nric should not be null");
+                                               "doctor nric");
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
     }
 
@@ -41,7 +41,7 @@ public class JsonAdaptedAppointmentTest {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, null,
                 VALID_START_DATE, VALID_END_DATE);
         String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
-                "appointment description should not be null");
+                "appointment description");
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
     }
 
@@ -50,7 +50,7 @@ public class JsonAdaptedAppointmentTest {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
                 null, VALID_END_DATE);
         String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
-                "start date should not be null");
+                "start date");
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
     }
 
@@ -59,7 +59,7 @@ public class JsonAdaptedAppointmentTest {
         JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
                 VALID_START_DATE, null);
         String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
-                "end date should not be null");
+                "end date");
         assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedAppointmentTest.java
@@ -1,0 +1,65 @@
+package seedu.address.storage;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.appointment.Appointment;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+public class JsonAdaptedAppointmentTest {
+
+    private static final String VALID_DOCTOR_NRIC = "S1234567A";
+    private static final String VALID_APPOINTMENT_DESCRIPTION = "Dental Checkup";
+    private static final String VALID_START_DATE = LocalDate.of(2020, 1, 1).toString();
+    private static final String VALID_END_DATE = LocalDate.of(2020, 1, 10).toString();
+
+    /**
+     * Ensures that the JsonAdaptedAppointment correctly converts a valid Appointment object into a JsonAdaptedAppointment
+     */
+    @Test
+    public void toModelType_validAppointmentDetails_returnsAppointment() throws Exception {
+        Appointment originalAppointment = new Appointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
+                LocalDate.parse(VALID_START_DATE), LocalDate.parse(VALID_END_DATE));
+        JsonAdaptedAppointment adaptedAppointment = new JsonAdaptedAppointment(originalAppointment);
+        assertEquals(originalAppointment, adaptedAppointment.toModelType());
+    }
+
+    @Test
+    public void toModelType_nullDoctorNric_throwsIllegalValueException() {
+        JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(null, VALID_APPOINTMENT_DESCRIPTION,
+                LocalDate.parse(VALID_START_DATE), LocalDate.parse(VALID_END_DATE));
+        String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
+                                               "doctor nric should not be null");
+        assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullAppointmentDescription_throwsIllegalValueException() {
+        JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, null,
+                LocalDate.parse(VALID_START_DATE), LocalDate.parse(VALID_END_DATE));
+        String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
+                "appointment description should not be null");
+        assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullStartDate_throwsIllegalValueException() {
+        JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
+                null, LocalDate.parse(VALID_END_DATE));
+        String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
+                "start date should not be null");
+        assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullEndDate_throwsIllegalValueException() {
+        JsonAdaptedAppointment appointment = new JsonAdaptedAppointment(VALID_DOCTOR_NRIC, VALID_APPOINTMENT_DESCRIPTION,
+                LocalDate.parse(VALID_START_DATE), null);
+        String expectedMessage = String.format(JsonAdaptedAppointment.MISSING_FIELD_MESSAGE_FORMAT,
+                "end date should not be null");
+        assertThrows(IllegalValueException.class, expectedMessage, appointment::toModelType);
+    }
+}


### PR DESCRIPTION
This PR adds a comprehensive test suite for the JsonAdaptedAppointment class to ensure the correctness of its toModelType() conversion logic and validation constraints.

✅ What's added
Unit tests for successful conversion from JsonAdaptedAppointment to Appointment when valid inputs are given.

Negative test cases for:

Missing doctor NRIC

Missing appointment description

Missing start date

Missing end date

Missing patient NRIC

LFG