### PR TITLE
Fix input bugs

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddMedicalReportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMedicalReportCommandParser.java
@@ -32,17 +32,23 @@ public class AddMedicalReportCommandParser implements Parser<AddMedicalReportCom
         if (!arePrefixesPresent(argMultimap, PREFIX_NRIC)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                                   AddMedicalReportCommand.MESSAGE_USAGE));
+                    AddMedicalReportCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_ALLERGY, PREFIX_ILLNESS,
-                                                 PREFIX_SURGERY, PREFIX_IMMUNIZATION);
+                PREFIX_SURGERY, PREFIX_IMMUNIZATION);
 
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
-        String allergy = argMultimap.getValue(PREFIX_ALLERGY).orElse("None");
-        String illness = argMultimap.getValue(PREFIX_ILLNESS).orElse("None");
-        String surgery = argMultimap.getValue(PREFIX_SURGERY).orElse("None");
-        String immunization = argMultimap.getValue(PREFIX_IMMUNIZATION).orElse("None");
+        String allergy = argMultimap.getValue(PREFIX_ALLERGY).orElse("None").trim();
+        String illness = argMultimap.getValue(PREFIX_ILLNESS).orElse("None").trim();
+        String surgery = argMultimap.getValue(PREFIX_SURGERY).orElse("None").trim();
+        String immunization = argMultimap.getValue(PREFIX_IMMUNIZATION).orElse("None").trim();
+
+        if (!isValidField(allergy) || !isValidField(illness)
+                || !isValidField(surgery) || !isValidField(immunization)) {
+            throw new ParseException(
+                    "Invalid input! fields must contain only letters, numbers, spaces, commas, hyphens.");
+        }
 
         MedicalReport medicalReport = new MedicalReport(allergy, illness, surgery, immunization);
 
@@ -55,5 +61,18 @@ public class AddMedicalReportCommandParser implements Parser<AddMedicalReportCom
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns true if the field is non-empty, trimmed, and matches allowed characters.
+     * Allowed: letters, numbers, spaces, commas, hyphens.
+     */
+    //Solution below inspired by:
+    //https://stackoverflow.com/questions/22990870/how-to-disable-emoji-from-being-entered-in-android-edittext
+    private boolean isValidField(String input) {
+        return input != null
+                && !input.trim().isEmpty()
+                && input.matches("^[a-zA-Z0-9 ,\\-]+$") // Only letters, numbers, spaces, commas, hyphens
+                && input.matches(".*[a-zA-Z].*"); // Must contain at least one alphabet
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddMedicalReportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMedicalReportCommandParser.java
@@ -39,16 +39,10 @@ public class AddMedicalReportCommandParser implements Parser<AddMedicalReportCom
                 PREFIX_SURGERY, PREFIX_IMMUNIZATION);
 
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
-        String allergy = argMultimap.getValue(PREFIX_ALLERGY).orElse("None").trim();
-        String illness = argMultimap.getValue(PREFIX_ILLNESS).orElse("None").trim();
-        String surgery = argMultimap.getValue(PREFIX_SURGERY).orElse("None").trim();
-        String immunization = argMultimap.getValue(PREFIX_IMMUNIZATION).orElse("None").trim();
-
-        if (!isValidField(allergy) || !isValidField(illness)
-                || !isValidField(surgery) || !isValidField(immunization)) {
-            throw new ParseException(
-                    "Invalid input! fields must contain only letters, numbers, spaces, commas, hyphens.");
-        }
+        String allergy = ParserUtil.parseMedicalField(argMultimap.getValue(PREFIX_ALLERGY).orElse("None"));
+        String illness = ParserUtil.parseMedicalField(argMultimap.getValue(PREFIX_ILLNESS).orElse("None"));
+        String surgery = ParserUtil.parseMedicalField(argMultimap.getValue(PREFIX_SURGERY).orElse("None"));
+        String immunization = ParserUtil.parseMedicalField(argMultimap.getValue(PREFIX_IMMUNIZATION).orElse("None"));
 
         MedicalReport medicalReport = new MedicalReport(allergy, illness, surgery, immunization);
 
@@ -61,19 +55,6 @@ public class AddMedicalReportCommandParser implements Parser<AddMedicalReportCom
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
-    /**
-     * Returns true if the field is non-empty, trimmed, and matches allowed characters.
-     * Allowed: letters, numbers, spaces, commas, hyphens.
-     */
-    //Solution below inspired by:
-    //https://stackoverflow.com/questions/22990870/how-to-disable-emoji-from-being-entered-in-android-edittext
-    private boolean isValidField(String input) {
-        return input != null
-                && !input.trim().isEmpty()
-                && input.matches("^[a-zA-Z0-9 ,\\-]+$") // Only letters, numbers, spaces, commas, hyphens
-                && input.matches(".*[a-zA-Z].*"); // Must contain at least one alphabet
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddMedicalReportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMedicalReportCommandParser.java
@@ -75,4 +75,9 @@ public class AddMedicalReportCommandParser implements Parser<AddMedicalReportCom
                 && input.matches("^[a-zA-Z0-9 ,\\-]+$") // Only letters, numbers, spaces, commas, hyphens
                 && input.matches(".*[a-zA-Z].*"); // Must contain at least one alphabet
     }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this || other instanceof AddMedicalReportCommandParser;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -184,4 +184,32 @@ public class ParserUtil {
         }
         return trimmedDoctorNric;
     }
+
+    /**
+     * Parses a medical report field (e.g. allergy, illness, etc.) and validates its format.
+     * Allowed characters: letters, numbers, spaces, commas, hyphens.
+     * Must not be empty or contain only numbers.
+     *
+     * @throws ParseException if the given {@code medicalField} is empty.
+     */
+    //Solution below inspired by:
+    //https://stackoverflow.com/questions/22990870/how-to-disable-emoji-from-being-entered-in-android-edittext
+    public static String parseMedicalField(String input) throws ParseException {
+        requireNonNull(input);
+        String trimmedInput = input.trim();
+
+        if (trimmedInput.isEmpty()) {
+            throw new ParseException("Field cannot be empty");
+        }
+
+        if (!trimmedInput.matches("^[a-zA-Z0-9 ,\\-]+$")) {
+            throw new ParseException(
+                    "Invalid input! Fields must contain only letters, numbers, spaces, commas, hyphens.");
+        }
+
+        if (!trimmedInput.matches(".*[a-zA-Z].*")) {
+            throw new ParseException("Field must contain at least one alphabet character.");
+        }
+        return trimmedInput;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,12 +10,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.BirthDate;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Nric;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.*;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -194,22 +189,12 @@ public class ParserUtil {
      */
     //Solution below inspired by:
     //https://stackoverflow.com/questions/22990870/how-to-disable-emoji-from-being-entered-in-android-edittext
-    public static String parseMedicalField(String input) throws ParseException {
-        requireNonNull(input);
-        String trimmedInput = input.trim();
-
-        if (trimmedInput.isEmpty()) {
-            throw new ParseException("Field cannot be empty");
+    public static String parseMedicalField(String field) throws ParseException {
+        requireNonNull(field);
+        String trimmedField = field.trim();
+        if (!MedicalReport.isValidMedicalField(trimmedField)) {
+            throw new ParseException(MedicalReport.MESSAGE_CONSTRAINTS);
         }
-
-        if (!trimmedInput.matches("^[a-zA-Z0-9 ,\\-]+$")) {
-            throw new ParseException(
-                    "Invalid input! Fields must contain only letters, numbers, spaces, commas, hyphens.");
-        }
-
-        if (!trimmedInput.matches(".*[a-zA-Z].*")) {
-            throw new ParseException("Field must contain at least one alphabet character.");
-        }
-        return trimmedInput;
+        return trimmedField;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -18,6 +18,7 @@ import seedu.address.model.medicineusage.MedicineName;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.BirthDate;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.MedicalReport;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Phone;

--- a/src/main/java/seedu/address/model/person/MedicalReport.java
+++ b/src/main/java/seedu/address/model/person/MedicalReport.java
@@ -12,6 +12,10 @@ import seedu.address.model.medicineusage.MedicineUsageList;
  */
 public class MedicalReport {
 
+    public static final String MESSAGE_CONSTRAINTS =
+            "Medical report should contain only letters, numbers, spaces, or hyphens, "
+                    + "and at least one alphabetic character";
+
     public static final MedicalReport EMPTY_MEDICAL_REPORT =
             new MedicalReport("None", "None", "None", "None");
 
@@ -104,6 +108,16 @@ public class MedicalReport {
                 + "  ➤ Surgeries: " + surgeries + "\n"
                 + "  ➤ Immunizations: " + immunizations
             );
+    }
+
+    /**
+     * Returns true if a given string is a valid medical report field
+     */
+    public static boolean isValidMedicalField(String input) {
+        return input != null
+                && !input.trim().isEmpty()
+                && input.matches("^[a-zA-Z0-9 ,\\-]+$")
+                && input.matches(".*[a-zA-Z].*");
     }
 }
 

--- a/src/test/java/seedu/address/logic/parser/AddMedicalReportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMedicalReportCommandParserTest.java
@@ -1,0 +1,68 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+
+public class AddMedicalReportCommandParserTest {
+
+    private final AddMedicalReportCommandParser parser = new AddMedicalReportCommandParser();
+
+    @Test
+    public void parse_invalidEmojiInput_throwsParseException() {
+        String input = "ic/S1234567A al/👁 ill/Flu sur/Appendectomy imm/Vaccine";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_emptyField_throwsParseException() {
+        String input = "ic/S1234567A al/ ill/Flu sur/Appendectomy imm/Vaccine";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_whitespaceOnlyField_throwsParseException() {
+        String input = "ic/S1234567A al/   ill/Flu sur/Appendectomy imm/Vaccine";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_fieldWithSpecialCharacters_throwsParseException() {
+        String input = "ic/S1234567A al/Dust$ ill/Flu sur/Appendectomy imm/^COVID-19";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_randomTextNoPrefix_throwsParseException() {
+        String input = "ic/S1234567A ill/Flu hello world al/Dust";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_inputWithSlashInsideValue_throwsParseException() {
+        String input = "ic/S1234567A al/Pollen ill/Flu/Cold sur/Appendectomy imm/Vaccine";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_inputWithOnlyNumbers_throwsParseException() {
+        String input = "ic/S1234567A al/12345 ill/1234 sur/4567 imm/890";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_missingNricPrefix_throwsParseException() {
+        String input = "al/Pollen ill/Flu sur/Appendectomy imm/COVID-19 Vaccine";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    public void parse_emptyInput_throwsParseException() {
+        String input = "";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+}


### PR DESCRIPTION
Summary:
This PR improves the robustness of the addmr (AddMedicalReport) command parser by fixing four key bugs related to invalid input handling. The fixes ensure that only well-formatted, meaningful user inputs are accepted for fields in the MedicalReport.

✅ Bug Fixes Addressed

1. ❌ Should not accept emoji input
	•	Before: Emoji characters like 👁 were allowed in fields.
	•	Now: Inputs must contain only letters, numbers, commas, hyphens, and at least one alphabetic character. Emoji and other symbols are rejected.

2. ❌ Should not accept random text with no prefix
	•	Before: Unprefixed input like hello world was merged with the last prefixed field.
	•	Now: Inputs with unexpected unprefixed text will trigger a ParseException and be rejected.

3. ❌ Should not accept whitespace-only fields
	•	Before: Fields like ill/    were accepted and saved as blank entries.
	•	Now: Fields must contain at least one non-whitespace character (and at least one letter) to be accepted.

4. ❌ Slash / inside field values is incorrectly parsed
	•	Before: Slash (/) within values caused misinterpretation (e.g., ill/Flu /ill boi).
	•	Now: Inputs are validated to match only allowed characters and explicitly reject slashes inside values.

🧪 How to Test

Try the following invalid inputs to verify that the parser correctly rejects them:
	•	addmr ic/S1234567A al/👁👁 ill/Flu
	•	addmr ic/S1234567A ill/Flu hello world al/Dust
	•	addmr ic/S1234567A sur/     
	•	addmr ic/S1234567A ill/Flu/Cold

Try these valid inputs to ensure behavior remains unchanged:
	•	addmr ic/S1234567A al/Pollen ill/Flu sur/Appendectomy imm/Flu Vaccine
	•	addmr ic/S1234567A al/None ill/None sur/None imm/None

💡 Implementation Notes
	•	Introduced a validation method isValidField() in AddMedicalReportCommandParser.
	•	Regex: ^[a-zA-Z0-9 ,\\-]+$ + must contain at least one [a-zA-Z].
	•	Input trimming and validation are done after ArgumentTokenizer.