### PR TITLE
Stricter medicine name equality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddMedicineUsageCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMedicineUsageCommand.java
@@ -37,6 +37,8 @@ public class AddMedicineUsageCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Medicine usage successfully added to %s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Patient with NRIC %s not found";
+    public static final String MESSAGE_MEDICINE_BEFORE_BIRTHDAY = "The added medicine usage starts before the "
+            + "patient's birthday!";
 
     private final Nric nric;
     private final MedicineUsage medicineUsage;
@@ -60,6 +62,10 @@ public class AddMedicineUsageCommand extends Command {
         Person person = model.findPersonByNric(nric);
         if (person == null) {
             throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND, nric));
+        }
+
+        if (!model.checkValidMedicineUsage(person, medicineUsage)) {
+            throw new CommandException(String.format(MESSAGE_MEDICINE_BEFORE_BIRTHDAY, nric));
         }
 
         model.addMedicineUsage(person, medicineUsage);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -148,4 +148,6 @@ public interface Model {
     void markAppointmentVisited(Person person, Appointment apptToMark);
 
     void unmarkAppointmentVisited(Person person, Appointment apptToMark);
+
+    boolean checkValidMedicineUsage(Person person, MedicineUsage medicineUsage);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -363,6 +363,18 @@ public class ModelManager implements Model {
         medicalReport.reset();
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
+
+    /**
+     * Checks if a person is born before a medicine usage start day (for validity check)
+     * @param target person to compare
+     * @param medicineUsage medicine usage to compare
+     * @return true if the person's birthday is before the medicine usage's start date
+     */
+    @Override
+    public boolean checkValidMedicineUsage(Person target, MedicineUsage medicineUsage) {
+        requireAllNonNull(target, medicineUsage);
+        return !target.bornAfter(medicineUsage.getStartDate());
+    }
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/medicineusage/MedicineName.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineName.java
@@ -38,6 +38,15 @@ public class MedicineName {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Checks if two medicine names have same name, this is a weaker equality.
+     * @param toCompare medicine name to compare.
+     * @return true if two medicine names are the same lowercase.
+     */
+    public boolean isSameName(MedicineName toCompare) {
+        return fullName.equalsIgnoreCase(toCompare.fullName);
+    }
+
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineUsage.java
@@ -80,7 +80,7 @@ public class MedicineUsage {
         boolean hasNoTimeOverlap = other.getStartDate().isAfter(this.getEndDate())
                 || other.getEndDate().isBefore(this.getStartDate());
 
-        return other.getName().equals(this.getName()) && !hasNoTimeOverlap;
+        return other.getName().isSameName(this.getName()) && !hasNoTimeOverlap;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/BirthDate.java
+++ b/src/main/java/seedu/address/model/person/BirthDate.java
@@ -62,6 +62,24 @@ public class BirthDate implements Comparable<BirthDate> {
         return age;
     }
 
+    /**
+     * Checks if birthday is after a certain day
+     * @param toCompare day to compare
+     * @return true if it is after {@code toCompare}, false otherwise
+     */
+    public boolean isAfter(LocalDate toCompare) {
+        return value.isAfter(toCompare);
+    }
+
+    /**
+     * Checks if birthday is before a certain day
+     * @param toCompare day to compare
+     * @return true if it is before {@code toCompare}, false otherwise
+     */
+    public boolean isBefore(LocalDate toCompare) {
+        return value.isBefore(toCompare);
+    }
+
     @Override
     public String toString() {
         return value.format(DATE_FORMATTER);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -145,6 +146,14 @@ public class Person {
         }
 
         return otherPerson != null && otherPerson.getNric().equals(getNric());
+    }
+
+    public boolean bornBefore(LocalDate toCompare) {
+        return birthDate.isBefore(toCompare);
+    }
+
+    public boolean bornAfter(LocalDate toCompare) {
+        return birthDate.isAfter(toCompare);
     }
 
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -246,6 +246,11 @@ public class AddCommandTest {
         public void unmarkAppointmentVisited(Person person, Appointment apptToMark) {
             throw new UnsupportedOperationException("This method should not be called");
         }
+
+        @Override
+        public boolean checkValidMedicineUsage(Person person, MedicineUsage medicineUsage) {
+            throw new UnsupportedOperationException("This method should not be called");
+        }
     }
 
     /**


### PR DESCRIPTION
Things changed:
- Medicine names are now checked ignoring case (`Paracetamol` is the same as `paracetamol`)

Reason: makes more sense 