### PR TITLE
Add index functionality to `deletemr` `delete` and `clearappt`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearAppointmentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearAppointmentsCommand.java
@@ -1,52 +1,94 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 
 /**
- * Clears all appointments of a person by NRIC.
+ * Clears all appointments of a person by NRIC or index.
  */
 public class ClearAppointmentsCommand extends Command {
 
     public static final String COMMAND_WORD = "clearappt";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Clears all appointments of a person identified by NRIC.\n"
-            + "Parameters: "
+            + ": Clears all appointments of a person identified by NRIC, OR by the index number used in the "
+            + "displayed patient list. However, it cannot be both NRIC and index.\n"
+            + "Parameters for first method: "
             + PREFIX_NRIC + "NRIC\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NRIC + "S1234567A\n";
+            + PREFIX_NRIC + "S1234567A\n"
+            + "Parameters for second method: "
+            + "INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_SUCCESS_APPOINTMENT = "Appointment successfully deleted from %s";
-    public static final String MESSAGE_SUCCESS_APPOINTMENTS = "Appointments successfully deleted from %s";
+    public static final String MESSAGE_SUCCESS_APPOINTMENT_NRIC = "Appointment successfully deleted from %s";
+    public static final String MESSAGE_SUCCESS_APPOINTMENT_ID = "Appointment successfully deleted from person"
+            + " at index %d";
+    public static final String MESSAGE_SUCCESS_APPOINTMENTS_NRIC = "Appointments successfully deleted from %s";
+    public static final String MESSAGE_SUCCESS_APPOINTMENTS_ID = "Appointments successfully deleted from person"
+            + " at index %d";
     public static final String MESSAGE_NO_APPOINTMENT = "No appointments to clear!";
-    public static final String MESSAGE_PERSON_NOT_FOUND = "Patient with NRIC %s not found";
+    public static final String MESSAGE_PERSON_NOT_FOUND_NRIC = "Patient with NRIC %s not found";
+    public static final String MESSAGE_PERSON_NOT_FOUND_ID = "Patient at index %d not found";
 
     private final Nric nric;
+    private final Index targetIndex;
 
     /**
-     * Creates an ClearAppointmentsCommand to delete all appointments of
+     * Creates a ClearAppointmentsCommand to delete all appointments of
      * the person identified by {@code Nric}.
      */
     public ClearAppointmentsCommand(Nric nric) {
         requireNonNull(nric);
         this.nric = nric;
+        this.targetIndex = null;
+        super.setShowConfirmation(true);
+    }
+
+    /**
+     * Creates a ClearAppointmentsCommand to delete all appointments of
+     * the person specified at {@code Index}.
+     */
+    public ClearAppointmentsCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
+        this.targetIndex = targetIndex;
+        this.nric = null;
         super.setShowConfirmation(true);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (nric != null) {
+            return executeByNric(nric, model);
+        } else {
+            return executeByIndex(targetIndex, model);
+        }
+    }
 
-
+    /**
+     * Executes the command given nric and model
+     * @param nric NRIC of the patient
+     * @param model Model that contains the patient
+     * @return Result of command execution
+     * @throws CommandException if error occurs during execution
+     */
+    private CommandResult executeByNric(Nric nric, Model model) throws CommandException {
+        requireAllNonNull(nric, model);
         Person person = model.findPersonByNric(nric);
+
         if (person == null) {
-            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND, nric));
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND_NRIC, nric));
         }
 
         int appointmentCount = person.getAppointments().size();
@@ -54,17 +96,68 @@ public class ClearAppointmentsCommand extends Command {
             return new CommandResult(MESSAGE_NO_APPOINTMENT);
         } else if (appointmentCount == 1) {
             model.clearAppointments(person);
-            return new CommandResult(String.format(MESSAGE_SUCCESS_APPOINTMENT, nric));
+            return new CommandResult(String.format(MESSAGE_SUCCESS_APPOINTMENT_NRIC, nric));
         } else {
             model.clearAppointments(person);
-            return new CommandResult(String.format(MESSAGE_SUCCESS_APPOINTMENTS, nric));
+            return new CommandResult(String.format(MESSAGE_SUCCESS_APPOINTMENTS_NRIC, nric));
+        }
+    }
+
+    /**
+     * Executes the command given index and model
+     * @param targetIndex Index of the person to execute on
+     * @param model Model that contains the person
+     * @return Results of command execution
+     * @throws CommandException if error occurs during execution
+     */
+    private CommandResult executeByIndex(Index targetIndex, Model model) throws CommandException {
+        requireAllNonNull(targetIndex, model);
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        Person person = lastShownList.get(targetIndex.getZeroBased());
+
+        if (person == null) {
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND_ID, targetIndex.getOneBased()));
+        }
+
+        int appointmentCount = person.getAppointments().size();
+        if (appointmentCount == 0) {
+            return new CommandResult(MESSAGE_NO_APPOINTMENT);
+        } else if (appointmentCount == 1) {
+            model.clearAppointments(person);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_APPOINTMENT_ID, targetIndex.getOneBased()));
+        } else {
+            model.clearAppointments(person);
+            return new CommandResult(String.format(MESSAGE_SUCCESS_APPOINTMENTS_ID, targetIndex.getOneBased()));
         }
     }
 
     @Override
     public boolean equals(Object other) {
-        return other == this
-                || (other instanceof ClearAppointmentsCommand
-                && nric.equals(((ClearAppointmentsCommand) other).nric));
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof ClearAppointmentsCommand)) {
+            return false;
+        }
+
+        ClearAppointmentsCommand otherCommand = (ClearAppointmentsCommand) other;
+
+        // Compare nric-based commands
+        if (this.nric != null && otherCommand.nric != null) {
+            return this.nric.equals(otherCommand.nric);
+        }
+
+        // Compare index-based commands
+        if (this.targetIndex != null && otherCommand.targetIndex != null) {
+            return this.targetIndex.equals(otherCommand.targetIndex);
+        }
+
+        // One uses nric, the other uses index
+        return false;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearMedicineUsageCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearMedicineUsageCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 
 /**
- * Clears all medicine usages of a person by NRIC.
+ * Clears all medicine usages of a person by NRIC or index.
  */
 public class ClearMedicineUsageCommand extends Command {
 
@@ -23,11 +23,11 @@ public class ClearMedicineUsageCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Clears all medicine usages of a patient identified by NRIC, OR by the index number used in the "
             + "displayed patient list. However, it cannot be both NRIC and index.\n"
-            + "Parameters for first approach: "
+            + "Parameters for first method: "
             + PREFIX_NRIC + "NRIC\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "S1234567A\n"
-            + "Parameters for second approach: "
+            + "Parameters for second method: "
             + "INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
@@ -46,8 +46,8 @@ public class ClearMedicineUsageCommand extends Command {
     private final Index targetIndex;
 
     /**
-     * Creates an ClearMedicineUsageCommand to delete all medicine usages of
-     * the person identified by {@code nric}.
+     * Creates a ClearMedicineUsageCommand to delete all medicine usages of
+     * the person identified by {@code Nric}.
      */
     public ClearMedicineUsageCommand(Nric nric) {
         requireNonNull(nric);
@@ -57,8 +57,8 @@ public class ClearMedicineUsageCommand extends Command {
     }
 
     /**
-     * Creates an ClearMedicineUsageCommand to delete all medicine usages of
-     * the person at the specified {@code targetIndex}
+     * Creates a ClearMedicineUsageCommand to delete all medicine usages of
+     * the person at the specified {@code Index}
      */
     public ClearMedicineUsageCommand(Index targetIndex) {
         requireNonNull(targetIndex);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -27,7 +27,8 @@ public class DeleteCommand extends Command {
             + PREFIX_NRIC + "NRIC\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "S1234567A\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Parameters for second method: "
+            + "INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Patient: %1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import java.util.List;
 
@@ -9,39 +11,99 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 
 /**
- * Deletes a patient identified using it's displayed index from the klinix.
+ * Deletes a patient identified using it's displayed index from the klinix or by nric.
  */
 public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the patient identified by the index number used in the displayed patient list.\n"
+            + ": Deletes the patient identified by the index number used in the displayed patient list or by nric.\n"
+            + "Parameters for first method: "
+            + PREFIX_NRIC + "NRIC\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NRIC + "S1234567A\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Patient: %1$s";
+    public static final String MESSAGE_PERSON_NOT_FOUND_NRIC = "Person with NRIC %s not found";
+    public static final String MESSAGE_PERSON_NOT_FOUND_ID = "Person at index %d not found";
 
+    private final Nric nric;
     private final Index targetIndex;
 
     /**
      * Creates a DeleteCommand to delete the person at the specified {@code targetIndex}.
      */
     public DeleteCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
         this.targetIndex = targetIndex;
+        this.nric = null;
+        super.setShowConfirmation(true);
+    }
+
+    /**
+     * Creates a DeleteCommand to delete the person with nric {@code nric}.
+     */
+    public DeleteCommand(Nric nric) {
+        requireNonNull(nric);
+        this.nric = nric;
+        this.targetIndex = null;
         super.setShowConfirmation(true);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Person> lastShownList = model.getFilteredPersonList();
+        if (nric != null) {
+            return executeByNric(nric, model);
+        } else {
+            return executeByIndex(targetIndex, model);
+        }
+    }
 
+    /**
+     * Executes the command given nric and model
+     * @param nric NRIC of the patient
+     * @param model Model that contains the patient
+     * @return Result of command execution
+     * @throws CommandException if error occurs during execution
+     */
+    private CommandResult executeByNric(Nric nric, Model model) throws CommandException {
+        requireAllNonNull(nric, model);
+        Person person = model.findPersonByNric(nric);
+
+        if (person == null) {
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND_NRIC, nric));
+        }
+
+        model.deletePerson(person);
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(person)));
+    }
+
+    /**
+     * Executes the command given index and model
+     * @param targetIndex Index of the person to execute on
+     * @param model Model that contains the person
+     * @return Results of command execution
+     * @throws CommandException if error occurs during execution
+     */
+    private CommandResult executeByIndex(Index targetIndex, Model model) throws CommandException {
+        requireAllNonNull(targetIndex, model);
+
+        List<Person> lastShownList = model.getFilteredPersonList();
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        Person person = lastShownList.get(targetIndex.getZeroBased());
+
+        if (person == null) {
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND_ID, targetIndex.getOneBased()));
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
@@ -51,17 +113,28 @@ public class DeleteCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
+        if (this == other) {
             return true;
         }
 
-        // instanceof handles nulls
         if (!(other instanceof DeleteCommand)) {
             return false;
         }
 
-        DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+        DeleteCommand otherCommand = (DeleteCommand) other;
+
+        // Compare nric-based commands
+        if (this.nric != null && otherCommand.nric != null) {
+            return this.nric.equals(otherCommand.nric);
+        }
+
+        // Compare index-based commands
+        if (this.targetIndex != null && otherCommand.targetIndex != null) {
+            return this.targetIndex.equals(otherCommand.targetIndex);
+        }
+
+        // One uses nric, the other uses index
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteMedicalReportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMedicalReportCommand.java
@@ -1,32 +1,46 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 
 /**
- * Deletes a medical report from a person identified by NRIC.
+ * Deletes a medical report from a person identified by NRIC or index.
  */
 public class DeleteMedicalReportCommand extends Command {
 
     public static final String COMMAND_WORD = "deletemr";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes a medical report from a patient identified by NRIC.\n"
-            + "Parameters: "
+            + ": Deletes a medical report from a patient identified by NRIC, OR by the index number used in the "
+            + "displayed patient list. However, it cannot be both NRIC and index.\n"
+            + "Parameters for first method: "
             + PREFIX_NRIC + "NRIC\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NRIC + "S1234567A";
+            + PREFIX_NRIC + "S1234567A\n"
+            + "Parameters for second method: "
+            + "INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_SUCCESS = "Medical report successfully deleted from %s";
-    public static final String MESSAGE_PERSON_NOT_FOUND = "Patient with NRIC %s not found";
-    public static final String MESSAGE_MEDICAL_REPORT_NOT_FOUND = "Medical report not found for %s";
+    public static final String MESSAGE_SUCCESS_NRIC = "Medical report successfully deleted from %s";
+    public static final String MESSAGE_SUCCESS_ID = "Medical report successfully deleted from person"
+            + " at index %d";
+    public static final String MESSAGE_PERSON_NOT_FOUND_NRIC = "Patient with NRIC %s not found";
+    public static final String MESSAGE_PERSON_NOT_FOUND_ID = "Patient at index %d not found";
+    public static final String MESSAGE_MEDICAL_REPORT_NOT_FOUND_NRIC = "Medical report not found for patient with %s";
+    public static final String MESSAGE_MEDICAL_REPORT_NOT_FOUND_ID = "Medical report not found for patient at index %d";
 
     private final Nric nric;
+    private final Index targetIndex;
 
     /**
      * Creates a DeleteMedicalReportCommand to remove the medical report of the specified person.
@@ -35,30 +49,105 @@ public class DeleteMedicalReportCommand extends Command {
     public DeleteMedicalReportCommand(Nric nric) {
         requireNonNull(nric);
         this.nric = nric;
+        this.targetIndex = null;
+        super.setShowConfirmation(true);
+    }
+
+    /**
+     * Creates a DeleteMedicalReportCommand to remove the medical report of the specified person.
+     * @param targetIndex Index of the person to delete in the currently displayed patient list.
+     */
+    public DeleteMedicalReportCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
+        this.targetIndex = targetIndex;
+        this.nric = null;
         super.setShowConfirmation(true);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (nric != null) {
+            return executeByNric(nric, model);
+        } else {
+            return executeByIndex(targetIndex, model);
+        }
+    }
 
+    /**
+     * Executes the command given nric and model
+     * @param nric NRIC of the patient
+     * @param model Model that contains the patient
+     * @return Result of command execution
+     * @throws CommandException if error occurs during execution
+     */
+    private CommandResult executeByNric(Nric nric, Model model) throws CommandException {
+        requireAllNonNull(nric, model);
         Person person = model.findPersonByNric(nric);
+
         if (person == null) {
-            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND, nric));
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND_NRIC, nric));
         }
 
         if (person.getMedicalReport() == null) {
-            throw new CommandException(String.format(MESSAGE_MEDICAL_REPORT_NOT_FOUND, nric));
+            throw new CommandException(String.format(MESSAGE_MEDICAL_REPORT_NOT_FOUND_NRIC, nric));
         }
 
         model.deleteMedicalReport(person);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, nric));
+        return new CommandResult(String.format(MESSAGE_SUCCESS_NRIC, nric));
+    }
+
+    /**
+     * Executes the command given index and model
+     * @param targetIndex Index of the person to execute on
+     * @param model Model that contains the person
+     * @return Results of command execution
+     * @throws CommandException if error occurs during execution
+     */
+    private CommandResult executeByIndex(Index targetIndex, Model model) throws CommandException {
+        requireAllNonNull(targetIndex, model);
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        Person person = lastShownList.get(targetIndex.getZeroBased());
+
+        if (person == null) {
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND_ID, targetIndex.getOneBased()));
+        }
+
+        if (person.getMedicalReport() == null) {
+            throw new CommandException(String.format(MESSAGE_MEDICAL_REPORT_NOT_FOUND_ID, targetIndex.getOneBased()));
+        }
+
+        model.deleteMedicalReport(person);
+        return new CommandResult(String.format(MESSAGE_SUCCESS_ID, targetIndex.getOneBased()));
     }
 
     @Override
     public boolean equals(Object other) {
-        return other == this
-                || (other instanceof DeleteMedicalReportCommand
-                && nric.equals(((DeleteMedicalReportCommand) other).nric));
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof DeleteMedicalReportCommand)) {
+            return false;
+        }
+
+        DeleteMedicalReportCommand otherCommand = (DeleteMedicalReportCommand) other;
+
+        // Compare nric-based commands
+        if (this.nric != null && otherCommand.nric != null) {
+            return this.nric.equals(otherCommand.nric);
+        }
+
+        // Compare index-based commands
+        if (this.targetIndex != null && otherCommand.targetIndex != null) {
+            return this.targetIndex.equals(otherCommand.targetIndex);
+        }
+
+        // One uses nric, the other uses index
+        return false;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ClearAppointmentsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearAppointmentsCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import java.util.stream.Stream;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearAppointmentsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Nric;
@@ -22,6 +23,22 @@ public class ClearAppointmentsCommandParser implements Parser<ClearAppointmentsC
     public ClearAppointmentsCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NRIC);
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC)) {
+            return parseByIndex(args);
+        } else {
+            return parseByNric(args);
+        }
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ClearAppointmentsCommand
+     * and returns an ClearAppointmentsCommand object for execution.
+     * Expects the format uses nric.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private ClearAppointmentsCommand parseByNric(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NRIC)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -34,6 +51,22 @@ public class ClearAppointmentsCommandParser implements Parser<ClearAppointmentsC
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
 
         return new ClearAppointmentsCommand(nric);
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ClearAppointmentsCommand
+     * and returns an ClearAppointmentsCommand object for execution.
+     * Expects the format uses index.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private ClearAppointmentsCommand parseByIndex(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new ClearAppointmentsCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearAppointmentsCommand.MESSAGE_USAGE), pe);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ClearMedicineUsageCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearMedicineUsageCommandParser.java
@@ -11,13 +11,13 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Nric;
 
 /**
- * Parses input arguments and creates a new AddMedicalReportCommand object
+ * Parses input arguments and creates a new ClearMedicineUsageCommandParser object
  */
 public class ClearMedicineUsageCommandParser implements Parser<ClearMedicineUsageCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddMedicineUsageCommand
-     * and returns an AddMedicineUsage object for execution.
+     * Parses the given {@code String} of arguments in the context of the ClearMedicineUsageCommand
+     * and returns an ClearMedicineUsageCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public ClearMedicineUsageCommand parse(String args) throws ParseException {
@@ -31,8 +31,8 @@ public class ClearMedicineUsageCommandParser implements Parser<ClearMedicineUsag
     }
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddMedicineUsageCommand
-     * and returns an AddMedicineUsage object for execution.
+     * Parses the given {@code String} of arguments in the context of the ClearMedicineUsageCommand
+     * and returns an ClearMedicineUsageCommand object for execution.
      * Expects the format uses nric.
      * @throws ParseException if the user input does not conform the expected format
      */
@@ -54,8 +54,8 @@ public class ClearMedicineUsageCommandParser implements Parser<ClearMedicineUsag
     }
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddMedicineUsageCommand
-     * and returns an AddMedicineUsage object for execution.
+     * Parses the given {@code String} of arguments in the context of the ClearMedicineUsageCommand
+     * and returns an ClearMedicineUsageCommand object for execution.
      * Expects the format uses index.
      * @throws ParseException if the user input does not conform the expected format
      */

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,10 +1,14 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Nric;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -17,6 +21,45 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC);
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC)) {
+            return parseByIndex(args);
+        } else {
+            return parseByNric(args);
+        }
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns a DeleteCommand object for execution.
+     * Expects the format uses nric.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private DeleteCommand parseByNric(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeleteCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC);
+
+        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+
+        return new DeleteCommand(nric);
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns a DeleteCommand object for execution.
+     * Expects the format uses index.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private DeleteCommand parseByIndex(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);
@@ -26,4 +69,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
     }
 
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteMedicalReportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMedicalReportCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import java.util.stream.Stream;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteMedicalReportCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Nric;
@@ -24,17 +25,53 @@ public class DeleteMedicalReportCommandParser implements Parser<DeleteMedicalRep
     public DeleteMedicalReportCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NRIC);
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC)) {
+            return parseByIndex(args);
+        } else {
+            return parseByNric(args);
+        }
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteMedicalReportCommand
+     * and returns an DeleteMedicalReportCommand object for execution.
+     * Expects the format uses index.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private DeleteMedicalReportCommand parseByIndex(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteMedicalReportCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMedicalReportCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteMedicalReportCommand
+     * and returns an DeleteMedicalReportCommand object for execution.
+     * Expects the format uses nric.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private DeleteMedicalReportCommand parseByNric(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NRIC)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                                   DeleteMedicalReportCommand.MESSAGE_USAGE));
+                    DeleteMedicalReportCommand.MESSAGE_USAGE));
         }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC);
 
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
 
         return new DeleteMedicalReportCommand(nric);
     }
+
+
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given

--- a/src/test/java/seedu/address/logic/commands/ClearAppointmentsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearAppointmentsCommandTest.java
@@ -1,0 +1,157 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.ModelManager;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.AppointmentList;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.BirthDate;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.MedicalReport;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+
+class ClearAppointmentsCommandTest {
+    private ModelManager model;
+    private Person person;
+    private Nric nric;
+    private Appointment appointment;
+
+    @BeforeEach
+    void setUp() {
+        model = new ModelManager();
+        nric = new Nric("S1234567A");
+        appointment = new Appointment("Checkup",
+                LocalDateTime.of(2025, 10, 1, 10, 0),
+                LocalDateTime.of(2025, 10, 1, 11, 0),
+                "S1234567A");
+
+        AppointmentList appointments = new AppointmentList();
+        appointments.add(appointment);
+
+        person = new Person(
+                new Name("John Doe"),
+                new Phone("12345678"),
+                new Email("john@example.com"),
+                nric,
+                new BirthDate("01-01-1990"),
+                new Address("123 Street"),
+                new HashSet<>(),
+                new MedicalReport("None", "None", "None", "None"),
+                appointments
+        );
+        model.addPerson(person);
+    }
+
+    @Test
+    void execute_nricWithOneAppointment_success() {
+        ClearAppointmentsCommand command = new ClearAppointmentsCommand(nric);
+        CommandResult result = assertDoesNotThrow(() -> command.execute(model));
+        assertEquals(String.format(ClearAppointmentsCommand.MESSAGE_SUCCESS_APPOINTMENT_NRIC, nric),
+                result.getFeedbackToUser());
+    }
+
+    @Test
+    void execute_nricWithNoAppointments_showsMessage() {
+        model.clearAppointments(person);
+        ClearAppointmentsCommand command = new ClearAppointmentsCommand(nric);
+        CommandResult result = assertDoesNotThrow(() -> command.execute(model));
+        assertEquals(ClearAppointmentsCommand.MESSAGE_NO_APPOINTMENT, result.getFeedbackToUser());
+    }
+
+    @Test
+    void execute_nricWithMultipleAppointments_success() {
+        Appointment another = new Appointment("Dental",
+                LocalDateTime.of(2025, 10, 2, 14, 0),
+                LocalDateTime.of(2025, 10, 2, 15, 0),
+                "S1234567A");
+        person.addAppointment(another);
+        ClearAppointmentsCommand command = new ClearAppointmentsCommand(nric);
+        CommandResult result = assertDoesNotThrow(() -> command.execute(model));
+        assertEquals(String.format(ClearAppointmentsCommand.MESSAGE_SUCCESS_APPOINTMENTS_NRIC, nric),
+                result.getFeedbackToUser());
+    }
+
+    @Test
+    void execute_nricNotFound_throwsCommandException() {
+        ClearAppointmentsCommand command = new ClearAppointmentsCommand(new Nric("S9999999Z"));
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    @Test
+    void execute_indexWithOneAppointment_success() {
+        ClearAppointmentsCommand command = new ClearAppointmentsCommand(Index.fromOneBased(1));
+        CommandResult result = assertDoesNotThrow(() -> command.execute(model));
+        assertEquals(String.format(ClearAppointmentsCommand.MESSAGE_SUCCESS_APPOINTMENT_ID, 1),
+                result.getFeedbackToUser());
+    }
+
+    @Test
+    void execute_indexWithMultipleAppointments_success() {
+        Appointment another = new Appointment("Dental",
+                LocalDateTime.of(2025, 10, 2, 14, 0),
+                LocalDateTime.of(2025, 10, 2, 15, 0),
+                "S1234567A");
+        person.addAppointment(another);
+        ClearAppointmentsCommand command = new ClearAppointmentsCommand(Index.fromOneBased(1));
+        CommandResult result = assertDoesNotThrow(() -> command.execute(model));
+        assertEquals(String.format(ClearAppointmentsCommand.MESSAGE_SUCCESS_APPOINTMENTS_ID, 1),
+                result.getFeedbackToUser());
+    }
+
+    @Test
+    void execute_indexWithNoAppointments_showsMessage() {
+        model.clearAppointments(person);
+        ClearAppointmentsCommand command = new ClearAppointmentsCommand(Index.fromOneBased(1));
+        CommandResult result = assertDoesNotThrow(() -> command.execute(model));
+        assertEquals(ClearAppointmentsCommand.MESSAGE_NO_APPOINTMENT, result.getFeedbackToUser());
+    }
+
+    @Test
+    void execute_indexOutOfBounds_throwsCommandException() {
+        ClearAppointmentsCommand command = new ClearAppointmentsCommand(Index.fromOneBased(5));
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    @Test
+    void equals_sameObject_returnsTrue() {
+        ClearAppointmentsCommand command = new ClearAppointmentsCommand(nric);
+        assertTrue(command.equals(command));
+    }
+
+    @Test
+    void equals_sameNric_returnsTrue() {
+        ClearAppointmentsCommand command1 = new ClearAppointmentsCommand(nric);
+        ClearAppointmentsCommand command2 = new ClearAppointmentsCommand(nric);
+        assertTrue(command1.equals(command2));
+    }
+
+    @Test
+    void equals_differentNric_returnsFalse() {
+        ClearAppointmentsCommand command1 = new ClearAppointmentsCommand(nric);
+        ClearAppointmentsCommand command2 = new ClearAppointmentsCommand(new Nric("S7654321B"));
+        assertFalse(command1.equals(command2));
+    }
+
+    @Test
+    void equals_differentMode_returnsFalse() {
+        ClearAppointmentsCommand command1 = new ClearAppointmentsCommand(nric);
+        ClearAppointmentsCommand command2 = new ClearAppointmentsCommand(Index.fromOneBased(1));
+        assertFalse(command1.equals(command2));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -17,6 +17,7 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 
 /**
@@ -39,6 +40,30 @@ public class DeleteCommandTest {
         expectedModel.deletePerson(personToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validNricUnfilteredList_success() {
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Nric nric = personToDelete.getNric();
+        DeleteCommand deleteCommand = new DeleteCommand(nric);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getKlinix(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidNricUnfilteredList_throwsCommandException() {
+        Nric invalidNric = new Nric("S9999999Z");
+        DeleteCommand deleteCommand = new DeleteCommand(invalidNric);
+
+        assertCommandFailure(deleteCommand, model, String.format(DeleteCommand.MESSAGE_PERSON_NOT_FOUND_NRIC,
+                invalidNric));
     }
 
     @Test
@@ -85,20 +110,20 @@ public class DeleteCommandTest {
         DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
 
         // same object -> returns true
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+        assertEquals(deleteFirstCommand, deleteFirstCommand);
 
         // same values -> returns true
         DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+        assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
 
         // different types -> returns false
-        assertFalse(deleteFirstCommand.equals(1));
+        assertNotEquals(1, deleteFirstCommand);
 
         // null -> returns false
-        assertFalse(deleteFirstCommand.equals(null));
+        assertNotEquals(null, deleteFirstCommand);
 
         // different person -> returns false
-        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+        assertNotEquals(deleteFirstCommand, deleteSecondCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ClearAppointmentsCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClearAppointmentsCommandParserTest.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ClearAppointmentsCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Nric;
+
+class ClearAppointmentsCommandParserTest {
+    private ClearAppointmentsCommandParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new ClearAppointmentsCommandParser();
+    }
+
+    @Test
+    void parse_validNric_success() throws ParseException {
+        String input = " ic/S1234567A";
+        ClearAppointmentsCommand command = parser.parse(input);
+        assertEquals(new ClearAppointmentsCommand(new Nric("S1234567A")), command);
+    }
+
+    @Test
+    void parse_validIndex_success() throws ParseException {
+        String input = " 1";
+        ClearAppointmentsCommand command = parser.parse(input);
+        assertEquals(new ClearAppointmentsCommand(Index.fromOneBased(1)), command);
+    }
+
+    @Test
+    void parse_invalidNricFormat_throwsParseException() {
+        String input = " ic/INVALID123";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_indexAndNricTogether_throwsParseException() {
+        String input = " 1 ic/S1234567A";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_nricThenIndex_throwsParseException() {
+        String input = " ic/S1234567A 1";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_duplicateNricPrefixes_throwsParseException() {
+        String input = " ic/S1234567A ic/S7654321B";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_extraTextAfterIndex_throwsParseException() {
+        String input = " 1 extra";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_emptyInput_throwsParseException() {
+        String input = " ";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,32 +1,69 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.person.Nric;
 
-/**
- * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the DeleteCommand, and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
- */
 public class DeleteCommandParserTest {
 
-    private DeleteCommandParser parser = new DeleteCommandParser();
+    private final DeleteCommandParser parser = new DeleteCommandParser();
 
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
+    public void parse_validIndex_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
     }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    public void parse_validNric_returnsDeleteCommand() {
+        assertParseSuccess(parser, " ic/S1234567A", new DeleteCommand(new Nric("S1234567A")));
+    }
+
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidNric_throwsParseException() {
+        assertParseFailure(parser, " ic/INVALID123", Nric.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_indexAndNricTogether_throwsParseException() {
+        assertParseFailure(parser, "1 ic/S1234567A", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_nricThenIndex_throwsParseException() {
+        assertParseFailure(parser, "ic/S1234567A 1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_duplicateNricPrefix_throwsParseException() {
+        assertParseFailure(parser, " ic/S1234567A ic/S7654321B",
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NRIC));
+    }
+
+    @Test
+    public void parse_extraTextAfterIndex_throwsParseException() {
+        assertParseFailure(parser, "1 extra", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyInput_throwsParseException() {
+        assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteMedicalReportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteMedicalReportCommandParserTest.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteMedicalReportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Nric;
+
+class DeleteMedicalReportCommandParserTest {
+    private DeleteMedicalReportCommandParser parser;
+
+    @BeforeEach
+    void setUp() {
+        parser = new DeleteMedicalReportCommandParser();
+    }
+
+    @Test
+    void parse_validNric_success() throws ParseException {
+        String input = " ic/S1234567A";
+        DeleteMedicalReportCommand command = parser.parse(input);
+        assertEquals(new DeleteMedicalReportCommand(new Nric("S1234567A")), command);
+    }
+
+    @Test
+    void parse_validIndex_success() throws ParseException {
+        String input = " 3";
+        DeleteMedicalReportCommand command = parser.parse(input);
+        assertEquals(new DeleteMedicalReportCommand(Index.fromOneBased(3)), command);
+    }
+
+    @Test
+    void parse_invalidNricFormat_throwsParseException() {
+        String input = " ic/123INVALID";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_indexAndNricTogether_throwsParseException() {
+        String input = " 1 ic/S1234567A";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_nricThenIndex_throwsParseException() {
+        String input = " ic/S1234567A 1";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_duplicateNricPrefix_throwsParseException() {
+        String input = " ic/S1234567A ic/S7654321B";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_extraTextAfterIndex_throwsParseException() {
+        String input = " 1 something";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+
+    @Test
+    void parse_emptyInput_throwsParseException() {
+        String input = " ";
+        assertThrows(ParseException.class, () -> parser.parse(input));
+    }
+}


### PR DESCRIPTION
Things to note:
- This is a follow-up PR from #200
- Implement functionality of `deletemr` `delete` and `clearappt` with index + nric
- Some test cases are added
Reason: 
- Users can choose which one they prefer
- Maintain consistency

Things to check:
- The logic should be the same as #200 
- Check comment headers