### PR TITLE
Fix bugs

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -13,16 +13,16 @@ public class StringUtil {
 
     /**
      * Returns true if the {@code sentence} contains the {@code word}.
-     *   Ignores case, but a full word match is required.
+     *   Ignores case, and partial word match is allowed.
      *   <br>examples:<pre>
-     *       containsWordIgnoreCase("ABc def", "abc") == true
-     *       containsWordIgnoreCase("ABc def", "DEF") == true
-     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
+     *       containsPartialWordIgnoreCase("ABc def", "abc") == true
+     *       containsPartialWordIgnoreCase("ABc def", "AB") == true //partial word match
+     *       containsPartialWordIgnoreCase("ABc def", "GHJ") == false //no match
      *       </pre>
      * @param sentence cannot be null
      * @param word cannot be null, cannot be empty, must be a single word
      */
-    public static boolean containsWordIgnoreCase(String sentence, String word) {
+    public static boolean containsPartialWordIgnoreCase(String sentence, String word) {
         requireNonNull(sentence);
         requireNonNull(word);
 

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Arrays;
 
 /**
  * Helper functions for handling strings.
@@ -31,11 +30,7 @@ public class StringUtil {
         checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
         checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
 
-        String preppedSentence = sentence;
-        String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
-
-        return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+        return sentence.toLowerCase().contains(preppedWord.toLowerCase());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/FindMedicineUsageCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindMedicineUsageCommand.java
@@ -17,7 +17,7 @@ public class FindMedicineUsageCommand extends Command {
     public static final String COMMAND_WORD = "findmu";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all medicine usages whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list of persons (users) "
+            + "the specified keywords (case-insensitive) and displays them as a list of patients "
             + "with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " paracetamol amoxicillin";

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -262,15 +262,21 @@ public class ParserUtil {
         }
     }
 
-    private static String smartTrim(String input) {
+    static String smartTrim(String input) {
         requireNonNull(input);
-        String trimmed = input.trim().replaceAll("\\s+", " "); // Trim white spaces
-        trimmed = trimmed.replaceAll("\\s*([-+@:])\\s*", "$1"); // Handle dashes and pluses
-        trimmed = trimmed.replaceAll("\\s*([.,])\\s*", "$1 "); // Handle commas and periods
-        trimmed = trimmed.replaceAll("\\s*([(#])\\s*", " $1"); // Handle left parenthesis
-        trimmed = trimmed.replaceAll("\\s*\\)\\s*", ") "); // Handle right parenthesis
-        trimmed = trimmed.replaceAll("\\s*'\\s*", "'"); // Handle apostrophes
-        trimmed = trimmed.replaceAll("\\s+", " ").trim(); // Trim white spaces again
+        // Handle characters one by one to avoid complication in rules conflict resolution
+        String trimmed = input.trim().replaceAll("\\s+", " "); // Remove extra white spaces
+        trimmed = trimmed.replaceAll("\\s*\\+\\s*", "+"); // Plus
+        trimmed = trimmed.replaceAll("\\s*@\\s*", "@"); // At
+        trimmed = trimmed.replaceAll("\\s*:\\s*", ":"); // Colon
+        trimmed = trimmed.replaceAll("\\s*'\\s*", "'"); // Apostrophe
+        trimmed = trimmed.replaceAll("\\s*\\.\\s*", ". "); // Period
+        trimmed = trimmed.replaceAll("\\s*,\\s*", ", "); // Comma
+        trimmed = trimmed.replaceAll("\\s*\\)\\s*", ") "); // Right parenthesis
+        trimmed = trimmed.replaceAll("\\s*\\(\\s*", " ("); // Left parenthesis
+        trimmed = trimmed.replaceAll("\\s*#\\s*", " #"); // Hash
+        trimmed = trimmed.replaceAll("\\s*\\-\\s*", "-"); // Dash
+        trimmed = trimmed.replaceAll("\\s+", " ").trim(); // Remove extra spaces again
 
         return trimmed;
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -58,7 +58,7 @@ public class ParserUtil {
      */
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
-        String trimmedName = name.trim();
+        String trimmedName = name.trim().replaceAll(" +", " ");
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
@@ -73,7 +73,7 @@ public class ParserUtil {
      */
     public static MedicineName parseMedicineName(String name) throws ParseException {
         requireNonNull(name);
-        String trimmedName = name.trim();
+        String trimmedName = name.trim().replaceAll(" +", " ");
         if (!MedicineName.isValidName(trimmedName)) {
             throw new ParseException(MedicineName.MESSAGE_CONSTRAINTS);
         }
@@ -88,7 +88,7 @@ public class ParserUtil {
      */
     public static Dosage parseDosage(String dosage) throws ParseException {
         requireNonNull(dosage);
-        String trimmedDosage = dosage.trim();
+        String trimmedDosage = dosage.trim().replaceAll(" +", " ");
         if (!Dosage.isValidDosage(trimmedDosage)) {
             throw new ParseException(Dosage.MESSAGE_CONSTRAINTS);
         }
@@ -103,7 +103,7 @@ public class ParserUtil {
      */
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
-        String trimmedPhone = phone.trim();
+        String trimmedPhone = phone.trim().replaceAll(" +", " ");
         if (!Phone.isValidPhone(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }
@@ -118,7 +118,7 @@ public class ParserUtil {
      */
     public static Address parseAddress(String address) throws ParseException {
         requireNonNull(address);
-        String trimmedAddress = address.trim();
+        String trimmedAddress = address.trim().replaceAll(" +", " ");
         if (!Address.isValidAddress(trimmedAddress)) {
             throw new ParseException(Address.MESSAGE_CONSTRAINTS);
         }
@@ -133,7 +133,7 @@ public class ParserUtil {
      */
     public static Email parseEmail(String email) throws ParseException {
         requireNonNull(email);
-        String trimmedEmail = email.trim();
+        String trimmedEmail = email.trim().replaceAll(" +", " ");
         if (!Email.isValidEmail(trimmedEmail)) {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
@@ -148,7 +148,7 @@ public class ParserUtil {
      */
     public static Nric parseNric(String nric) throws ParseException {
         requireNonNull(nric);
-        String trimmedNric = nric.trim();
+        String trimmedNric = nric.trim().replaceAll(" +", " ");
         if (!Nric.isValidNric(trimmedNric)) {
             throw new ParseException(Nric.MESSAGE_CONSTRAINTS);
         }
@@ -163,7 +163,7 @@ public class ParserUtil {
      */
     public static BirthDate parseBirthDate(String birthDate) throws ParseException {
         requireNonNull(birthDate);
-        String trimmedBirthDate = birthDate.trim();
+        String trimmedBirthDate = birthDate.trim().replaceAll(" +", " ");
         if (!BirthDate.isValidBirthDate(trimmedBirthDate)) {
             throw new ParseException(BirthDate.MESSAGE_CONSTRAINTS);
         }
@@ -178,7 +178,7 @@ public class ParserUtil {
      */
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
-        String trimmedTag = tag.trim();
+        String trimmedTag = tag.trim().replaceAll(" +", " ");
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
@@ -205,7 +205,7 @@ public class ParserUtil {
      */
     public static String parseAppointmentDescription(String appointmentDescription) throws ParseException {
         requireNonNull(appointmentDescription);
-        String trimmedAppointmentDescription = appointmentDescription.trim();
+        String trimmedAppointmentDescription = appointmentDescription.trim().replaceAll(" +", " ");
         if (!Appointment.isValidDescription(trimmedAppointmentDescription)) {
             throw new ParseException(Appointment.DESCRIPTION_MESSAGE_CONSTRAINTS);
         }
@@ -223,7 +223,7 @@ public class ParserUtil {
     //https://stackoverflow.com/questions/22990870/how-to-disable-emoji-from-being-entered-in-android-edittext
     public static String parseMedicalField(String field) throws ParseException {
         requireNonNull(field);
-        String trimmedField = field.trim();
+        String trimmedField = field.trim().replaceAll(" +", " ");
         if (!MedicalReport.isValidMedicalField(trimmedField)) {
             throw new ParseException(MedicalReport.MESSAGE_CONSTRAINTS);
         }
@@ -238,7 +238,7 @@ public class ParserUtil {
      */
     public static LocalDateTime parseLocalDateTime(String dateTime) throws ParseException {
         requireNonNull(dateTime);
-        String trimmedDateTime = dateTime.trim();
+        String trimmedDateTime = dateTime.trim().replaceAll(" +", " ");
         try {
             return LocalDateTime.parse(trimmedDateTime, DATE_TIME_FORMATTER);
         } catch (DateTimeParseException exception) {
@@ -254,7 +254,7 @@ public class ParserUtil {
      */
     public static LocalDate parseLocalDate(String date) throws ParseException {
         requireNonNull(date);
-        String trimmedDate = date.trim();
+        String trimmedDate = date.trim().replaceAll(" +", " ");
         try {
             return LocalDate.parse(trimmedDate, DATE_FORMATTER);
         } catch (DateTimeParseException exception) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -43,7 +43,7 @@ public class ParserUtil {
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
-        String trimmedIndex = oneBasedIndex.trim();
+        String trimmedIndex = oneBasedIndex.replaceAll("\\s+", ""); // Remove all white spaces
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
@@ -58,7 +58,7 @@ public class ParserUtil {
      */
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
-        String trimmedName = name.trim().replaceAll(" +", " ");
+        String trimmedName = smartTrim(name);
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
@@ -73,7 +73,7 @@ public class ParserUtil {
      */
     public static MedicineName parseMedicineName(String name) throws ParseException {
         requireNonNull(name);
-        String trimmedName = name.trim().replaceAll(" +", " ");
+        String trimmedName = smartTrim(name);
         if (!MedicineName.isValidName(trimmedName)) {
             throw new ParseException(MedicineName.MESSAGE_CONSTRAINTS);
         }
@@ -88,7 +88,7 @@ public class ParserUtil {
      */
     public static Dosage parseDosage(String dosage) throws ParseException {
         requireNonNull(dosage);
-        String trimmedDosage = dosage.trim().replaceAll(" +", " ");
+        String trimmedDosage = smartTrim(dosage);
         if (!Dosage.isValidDosage(trimmedDosage)) {
             throw new ParseException(Dosage.MESSAGE_CONSTRAINTS);
         }
@@ -103,7 +103,7 @@ public class ParserUtil {
      */
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
-        String trimmedPhone = phone.trim().replaceAll(" +", " ");
+        String trimmedPhone = phone.replaceAll("\\s+", ""); // Remove all white spaces
         if (!Phone.isValidPhone(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }
@@ -118,7 +118,7 @@ public class ParserUtil {
      */
     public static Address parseAddress(String address) throws ParseException {
         requireNonNull(address);
-        String trimmedAddress = address.trim().replaceAll(" +", " ");
+        String trimmedAddress = smartTrim(address);
         if (!Address.isValidAddress(trimmedAddress)) {
             throw new ParseException(Address.MESSAGE_CONSTRAINTS);
         }
@@ -133,7 +133,7 @@ public class ParserUtil {
      */
     public static Email parseEmail(String email) throws ParseException {
         requireNonNull(email);
-        String trimmedEmail = email.trim().replaceAll(" +", " ");
+        String trimmedEmail = email.replaceAll("\\s+", ""); // Remove all white spaces
         if (!Email.isValidEmail(trimmedEmail)) {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
@@ -148,7 +148,7 @@ public class ParserUtil {
      */
     public static Nric parseNric(String nric) throws ParseException {
         requireNonNull(nric);
-        String trimmedNric = nric.trim().replaceAll(" +", " ");
+        String trimmedNric = nric.replaceAll("\\s+", ""); // Remove all white spaces
         if (!Nric.isValidNric(trimmedNric)) {
             throw new ParseException(Nric.MESSAGE_CONSTRAINTS);
         }
@@ -163,7 +163,7 @@ public class ParserUtil {
      */
     public static BirthDate parseBirthDate(String birthDate) throws ParseException {
         requireNonNull(birthDate);
-        String trimmedBirthDate = birthDate.trim().replaceAll(" +", " ");
+        String trimmedBirthDate = birthDate.replaceAll("\\s+", ""); // Remove all white spaces
         if (!BirthDate.isValidBirthDate(trimmedBirthDate)) {
             throw new ParseException(BirthDate.MESSAGE_CONSTRAINTS);
         }
@@ -178,7 +178,7 @@ public class ParserUtil {
      */
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
-        String trimmedTag = tag.trim().replaceAll(" +", " ");
+        String trimmedTag = smartTrim(tag);
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
@@ -205,7 +205,7 @@ public class ParserUtil {
      */
     public static String parseAppointmentDescription(String appointmentDescription) throws ParseException {
         requireNonNull(appointmentDescription);
-        String trimmedAppointmentDescription = appointmentDescription.trim().replaceAll(" +", " ");
+        String trimmedAppointmentDescription = smartTrim(appointmentDescription);
         if (!Appointment.isValidDescription(trimmedAppointmentDescription)) {
             throw new ParseException(Appointment.DESCRIPTION_MESSAGE_CONSTRAINTS);
         }
@@ -223,7 +223,7 @@ public class ParserUtil {
     //https://stackoverflow.com/questions/22990870/how-to-disable-emoji-from-being-entered-in-android-edittext
     public static String parseMedicalField(String field) throws ParseException {
         requireNonNull(field);
-        String trimmedField = field.trim().replaceAll(" +", " ");
+        String trimmedField = smartTrim(field);
         if (!MedicalReport.isValidMedicalField(trimmedField)) {
             throw new ParseException(MedicalReport.MESSAGE_CONSTRAINTS);
         }
@@ -238,7 +238,7 @@ public class ParserUtil {
      */
     public static LocalDateTime parseLocalDateTime(String dateTime) throws ParseException {
         requireNonNull(dateTime);
-        String trimmedDateTime = dateTime.trim().replaceAll(" +", " ");
+        String trimmedDateTime = smartTrim(dateTime);
         try {
             return LocalDateTime.parse(trimmedDateTime, DATE_TIME_FORMATTER);
         } catch (DateTimeParseException exception) {
@@ -254,11 +254,24 @@ public class ParserUtil {
      */
     public static LocalDate parseLocalDate(String date) throws ParseException {
         requireNonNull(date);
-        String trimmedDate = date.trim().replaceAll(" +", " ");
+        String trimmedDate = date.replaceAll("\\s+", ""); // Remove all white spaces
         try {
             return LocalDate.parse(trimmedDate, DATE_FORMATTER);
         } catch (DateTimeParseException exception) {
             throw new ParseException(INVALID_DATE_MESSAGE + DATE_INVALID_SPECIFY + trimmedDate, exception);
         }
+    }
+
+    private static String smartTrim(String input) {
+        requireNonNull(input);
+        String trimmed = input.trim().replaceAll("\\s+", " "); // Trim white spaces
+        trimmed = trimmed.replaceAll("\\s*([-+@:])\\s*", "$1"); // Handle dashes and pluses
+        trimmed = trimmed.replaceAll("\\s*([.,])\\s*", "$1 "); // Handle commas and periods
+        trimmed = trimmed.replaceAll("\\s*([(#])\\s*", " $1"); // Handle left parenthesis
+        trimmed = trimmed.replaceAll("\\s*\\)\\s*", ") "); // Handle right parenthesis
+        trimmed = trimmed.replaceAll("\\s*'\\s*", "'"); // Handle apostrophes
+        trimmed = trimmed.replaceAll("\\s+", " ").trim(); // Trim white spaces again
+
+        return trimmed;
     }
 }

--- a/src/main/java/seedu/address/model/medicineusage/MedicineName.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineName.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class MedicineName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Medicine names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Medicine names should only contain ()+,.' alphanumeric characters and spaces. It should not be blank";
 
     /*
      * The first character of the medicine name must not be a whitespace,

--- a/src/main/java/seedu/address/model/medicineusage/MedicineName.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineName.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class MedicineName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Medicine names should only contain ()+,.' alphanumeric characters and spaces. It should not be blank";
+            "Medicine names should only contain -()+,.' alphanumeric characters and spaces. It should not be blank";
 
     /*
      * The first character of the medicine name must not be a whitespace,

--- a/src/main/java/seedu/address/model/medicineusage/MedicineName.java
+++ b/src/main/java/seedu/address/model/medicineusage/MedicineName.java
@@ -16,7 +16,7 @@ public class MedicineName {
      * The first character of the medicine name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}[\\p{Alnum} \\-()+,.']*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/MedicineUsageContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/MedicineUsageContainsKeywordsPredicate.java
@@ -22,7 +22,7 @@ public class MedicineUsageContainsKeywordsPredicate implements Predicate<Person>
         List<MedicineName> medicineNames = person.getMedicineUsageNames();
         return keywords.stream().anyMatch(keyword ->
                 medicineNames.stream().anyMatch(name ->
-                        StringUtil.containsWordIgnoreCase(name.toString(), keyword)));
+                        StringUtil.containsPartialWordIgnoreCase(name.toString(), keyword)));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsPartialWordIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -55,25 +55,26 @@ public class StringUtilTest {
      */
 
     @Test
-    public void containsWordIgnoreCase_nullWord_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsWordIgnoreCase("typical sentence", null));
+    public void containsWordIgnoreCase_nullPartial_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsPartialWordIgnoreCase("typical sentence",
+                null));
     }
 
     @Test
-    public void containsWordIgnoreCase_emptyWord_throwsIllegalArgumentException() {
+    public void containsWordIgnoreCase_emptyPartial_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, "Word parameter cannot be empty", ()
-            -> StringUtil.containsWordIgnoreCase("typical sentence", "  "));
+            -> StringUtil.containsPartialWordIgnoreCase("typical sentence", "  "));
     }
 
     @Test
-    public void containsWordIgnoreCase_multipleWords_throwsIllegalArgumentException() {
+    public void containsPartialWordIgnoreCase_multipleWords_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, "Word parameter should be a single word", ()
-            -> StringUtil.containsWordIgnoreCase("typical sentence", "aaa BBB"));
+            -> StringUtil.containsPartialWordIgnoreCase("typical sentence", "aaa BBB"));
     }
 
     @Test
-    public void containsWordIgnoreCase_nullSentence_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> StringUtil.containsWordIgnoreCase(null, "abc"));
+    public void containsPartialWordIgnoreCase_nullSentence_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.containsPartialWordIgnoreCase(null, "abc"));
     }
 
     /*
@@ -102,26 +103,46 @@ public class StringUtilTest {
      */
 
     @Test
-    public void containsWordIgnoreCase_validInputs_correctResult() {
+    public void containsPartialWordIgnoreCase_validInputs_correctResult() {
+        // Empty sentence or keyword
+        assertFalse(StringUtil.containsPartialWordIgnoreCase("", "abc")); // empty sentence
+        assertThrows(IllegalArgumentException.class, () ->
+                StringUtil.containsPartialWordIgnoreCase("abc", ""));
 
-        // Empty sentence
-        assertFalse(StringUtil.containsWordIgnoreCase("", "abc")); // Boundary case
-        assertFalse(StringUtil.containsWordIgnoreCase("    ", "123"));
+        // Sentence contains keyword as partial substring
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("paracetamol ibuprofen", "mol")); // partial middle
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("Vitamin C + Zinc", "vit")); // partial front
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("Amoxicillin", "illin")); // partial end
 
-        // Matches a partial word only
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
+        // Keyword longer than any word in sentence – no match
+        assertFalse(StringUtil.containsPartialWordIgnoreCase("aaa bbb ccc", "bbbbbb")); // too long
 
-        // Matches word in the sentence, different upper/lower case letters
-        assertTrue(StringUtil.containsWordIgnoreCase("aaa bBb ccc", "Bbb")); // First word (boundary case)
-        assertTrue(StringUtil.containsWordIgnoreCase("aaa bBb ccc@1", "CCc@1")); // Last word (boundary case)
-        assertTrue(StringUtil.containsWordIgnoreCase("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces
-        assertTrue(StringUtil.containsWordIgnoreCase("Aaa", "aaa")); // Only one word in sentence (boundary case)
-        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "  ccc  ")); // Leading/trailing spaces
+        // Case-insensitive match
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("AAA bBb ccc", "bbb")); // match with different case
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("Zyrtec (Cetirizine)", "CETI")); // caps vs lowercase
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("Dr. John's formula", "john")); // with punctuation
 
-        // Matches multiple words in sentence
-        assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
+        // Sentence has leading/trailing/multiple spaces
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("   aaa   bbb   ccc   ", "bb")); // extra spaces
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("   Aaa", "aaa")); // leading spaces
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("ccc   ", "c")); // trailing spaces
+
+        // Match is full word
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("abc def ghi", "def"));
+
+        // Match is entire sentence
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("hydrocortisone", "hydrocortisone"));
+
+        // Match is across symbols
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("Aspirin + Paracetamol", "+"));
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("Aspirin-Paracetamol", "-"));
+        assertTrue(StringUtil.containsPartialWordIgnoreCase("Cough, Cold, Fever", ","));
+
+        // No match
+        assertFalse(StringUtil.containsPartialWordIgnoreCase("Ibuprofen", "paracetamol"));
+        assertFalse(StringUtil.containsPartialWordIgnoreCase("abc def", "xyz"));
     }
+
 
     //---------------- Tests for getDetails --------------------------------------
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -6,17 +6,25 @@ import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.medicineusage.Dosage;
+import seedu.address.model.medicineusage.MedicineName;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.BirthDate;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Nric;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
@@ -192,5 +200,248 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    // Whitespace normalization
+    @Test
+    public void smartTrim_whitespaceOnly_returnsEmpty() {
+        assertEquals("", ParserUtil.smartTrim("     "));
+        assertEquals("", ParserUtil.smartTrim("\n\t  "));
+    }
+
+    @Test
+    public void smartTrim_multipleSpaces_collapsesCorrectly() {
+        assertEquals("a b c", ParserUtil.smartTrim("a     b\t  c"));
+    }
+
+    // Dash
+    @Test
+    public void smartTrim_dash_hasNoSpacesAround() {
+        assertEquals("2023-2024", ParserUtil.smartTrim("2023 - 2024"));
+    }
+
+    // Plus
+    @Test
+    public void smartTrim_plus_hasNoSpacesAround() {
+        assertEquals("A+B", ParserUtil.smartTrim(" A + B "));
+    }
+
+    // At symbol
+    @Test
+    public void smartTrim_atSymbol_hasNoSpacesAround() {
+        assertEquals("name@example. com", ParserUtil.smartTrim("name @ example.com"));
+    }
+
+    // Colon
+    @Test
+    public void smartTrim_colon_hasNoSpacesAround() {
+        assertEquals("Time:10AM", ParserUtil.smartTrim(" Time : 10AM "));
+    }
+
+    // Apostrophe
+    @Test
+    public void smartTrim_apostrophe_hasNoSpacesAround() {
+        assertEquals("John's book", ParserUtil.smartTrim("John ' s book"));
+    }
+
+    // Period
+    @Test
+    public void smartTrim_period_hasNoSpaceBeforeOneAfter() {
+        assertEquals("e. g. example", ParserUtil.smartTrim("e . g .example"));
+    }
+
+    // Comma
+    @Test
+    public void smartTrim_comma_hasNoSpaceBeforeOneAfter() {
+        assertEquals("a, b, c", ParserUtil.smartTrim("a ,b ,  c"));
+    }
+
+    // Parentheses
+    @Test
+    public void smartTrim_leftParenthesis_hasOneSpaceBefore() {
+        assertEquals("Vitamin C (500mg)", ParserUtil.smartTrim("Vitamin C( 500mg)"));
+    }
+
+    @Test
+    public void smartTrim_rightParenthesis_hasOneSpaceAfter() {
+        assertEquals("a (b) c", ParserUtil.smartTrim("a(b )  c"));
+    }
+
+    // Hash
+    @Test
+    public void smartTrim_hash_hasOneSpaceBefore() {
+        assertEquals("Label #Tag", ParserUtil.smartTrim("Label#Tag"));
+    }
+
+    // Combination and real-world input
+    @Test
+    public void smartTrim_combination_fullFormatting() {
+        String input = "  Dr .  John ' s  Clinic  (Room 3) - 24 + 7  @ hospital.com ";
+        String expected = "Dr. John's Clinic (Room 3)-24+7@hospital. com";
+        assertEquals(expected, ParserUtil.smartTrim(input));
+    }
+
+    @Test
+    public void smartTrim_complexSpacingAndPunctuation() {
+        String input = "This , is  a  test .  Check ( formatting ) -  now + then @here: ok";
+        String expected = "This, is a test. Check (formatting)-now+then@here:ok";
+        assertEquals(expected, ParserUtil.smartTrim(input));
+    }
+
+    // Empty input
+    @Test
+    public void smartTrim_emptyInput_returnsEmpty() {
+        assertEquals("", ParserUtil.smartTrim(""));
+    }
+
+    @Test
+    public void parseIndex_validInput_success2() throws Exception {
+        assertEquals(Index.fromOneBased(1), ParserUtil.parseIndex(" 1 "));
+        assertEquals(Index.fromOneBased(42), ParserUtil.parseIndex("   42\t"));
+    }
+
+    @Test
+    public void parseIndex_invalidInput_throwsParseException2() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("0"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("-5"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("abc"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("  4a  "));
+    }
+
+    @Test
+    public void parseName_valid_success() throws Exception {
+        assertEquals(new Name("John Doe"), ParserUtil.parseName(" John  Doe "));
+    }
+
+    @Test
+    public void parseName_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseName(""));
+        assertThrows(ParseException.class, () -> ParserUtil.parseName("###"));
+    }
+
+    @Test
+    public void parseMedicineName_valid_success() throws Exception {
+        assertEquals(new MedicineName("Paracetamol 500mg"), ParserUtil.parseMedicineName(" Paracetamol  500mg "));
+    }
+
+    @Test
+    public void parseMedicineName_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMedicineName("   "));
+        assertThrows(ParseException.class, () -> ParserUtil.parseMedicineName("!!@@"));
+    }
+
+    @Test
+    public void parseDosage_valid_success() throws Exception {
+        assertEquals(new Dosage("1 tablet"), ParserUtil.parseDosage(" 1  tablet "));
+    }
+
+    @Test
+    public void parseDosage_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDosage("!!"));
+    }
+
+    @Test
+    public void parsePhone_valid_success() throws Exception {
+        assertEquals(new Phone("91234567"), ParserUtil.parsePhone("  9123 4567 "));
+    }
+
+    @Test
+    public void parsePhone_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePhone("12"));
+        assertThrows(ParseException.class, () -> ParserUtil.parsePhone("phone"));
+    }
+
+    @Test
+    public void parseEmail_valid_success() throws Exception {
+        assertEquals(new Email("test@example.com"), ParserUtil.parseEmail(" test @ example . com "));
+    }
+
+    @Test
+    public void parseEmail_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseEmail("test@@example.com"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseEmail("test.com"));
+    }
+
+    @Test
+    public void parseNric_valid_success() throws Exception {
+        assertEquals(new Nric("S1234567D"), ParserUtil.parseNric(" S1234  567D "));
+    }
+
+    @Test
+    public void parseNric_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseNric("S12A"));
+    }
+
+    @Test
+    public void parseBirthDate_valid_success() throws Exception {
+        assertEquals(new BirthDate("01-01-2000"), ParserUtil.parseBirthDate("01  -  01 - 20 00"));
+    }
+
+    @Test
+    public void parseBirthDate_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseBirthDate("2000-01-01"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseBirthDate("invalid"));
+    }
+
+    @Test
+    public void parseTag_valid_success() throws Exception {
+        assertEquals(new Tag("urgent"), ParserUtil.parseTag(" urgent "));
+    }
+
+    @Test
+    public void parseTag_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTag("!!!"));
+    }
+
+    @Test
+    public void parseTags_valid_success() throws Exception {
+        Set<Tag> tags = ParserUtil.parseTags(List.of(" urgent ", " general "));
+        assertTrue(tags.contains(new Tag("urgent")));
+        assertTrue(tags.contains(new Tag("general")));
+    }
+
+    @Test
+    public void parseAppointmentDescription_valid_success() throws Exception {
+        assertEquals("Check-up (fasting)",
+                ParserUtil.parseAppointmentDescription("  Check -  up  ( fasting ) "));
+    }
+
+    @Test
+    public void parseAppointmentDescription_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseAppointmentDescription(""));
+    }
+
+    @Test
+    public void parseMedicalField_valid_success() throws Exception {
+        assertEquals("Peanut allergy", ParserUtil.parseMedicalField("Peanut   allergy"));
+    }
+
+    @Test
+    public void parseMedicalField_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMedicalField("12345")); // only digits
+        assertThrows(ParseException.class, () -> ParserUtil.parseMedicalField("")); // empty
+    }
+
+    @Test
+    public void parseLocalDateTime_valid_success() throws Exception {
+        LocalDateTime expected = LocalDateTime.of(2025, 4, 5, 14, 30);
+        assertEquals(expected, ParserUtil.parseLocalDateTime("05-04-2025 14:30"));
+    }
+
+    @Test
+    public void parseLocalDateTime_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseLocalDateTime("2025-04-05T14:30"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseLocalDateTime("invalid date"));
+    }
+
+    @Test
+    public void parseLocalDate_valid_success() throws Exception {
+        assertEquals(LocalDate.of(2024, 12, 31), ParserUtil.parseLocalDate("31-12-2024"));
+    }
+
+    @Test
+    public void parseLocalDate_invalid_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseLocalDate("31/12/2024"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseLocalDate("abcd"));
     }
 }


### PR DESCRIPTION
Bugs that are fixed:
- Not able to trim spaces in between words --> fix and enhance trimming for all inputs of `ParserUtil`
- Cannot find partial matching --> fixed, now for `find` and `findmu` will use partial matching, added some test cases also
- `MedicineName` cannot take valid medicines --> fixed, now allow alphanumeric, spaces and ()+,.'

Things to note:
- New trimming method: `smartTrim` allows handling descriptive text string (name, description, ...). While more confined text input (like email, birthday, nric,...) implement simple "remove all white spaces" method

Things to check:
- Check the code for `smartTrim`, see if it conflicts with your command or anything.
- Test out and verify the above bugs are fixed