### PR TITLE
Refactor name parsing logic and improve smartTrimName method

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -58,7 +58,7 @@ public class ParserUtil {
      */
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
-        String trimmedName = smartTrim(name);
+        String trimmedName = smartTrimName(name);
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
@@ -275,6 +275,20 @@ public class ParserUtil {
         trimmed = trimmed.replaceAll("\\s*\\)\\s*", ") "); // Right parenthesis
         trimmed = trimmed.replaceAll("\\s*\\(\\s*", " ("); // Left parenthesis
         trimmed = trimmed.replaceAll("\\s*#\\s*", " #"); // Hash
+        trimmed = trimmed.replaceAll("\\s*\\-\\s*", "-"); // Dash
+        trimmed = trimmed.replaceAll("\\s+", " ").trim(); // Remove extra spaces again
+
+        return trimmed;
+    }
+
+    static String smartTrimName(String input) {
+        requireNonNull(input);
+        // Handle characters one by one to avoid complication in rules conflict resolution
+        String trimmed = input.trim().replaceAll("\\s+", " "); // Remove extra white spaces
+        trimmed = trimmed.replaceAll("\\s*\\.\\s*", ". "); // Plus
+        trimmed = trimmed.replaceAll("\\s*@\\s*", " @ "); // At
+        trimmed = trimmed.replaceAll("\\s*:\\s*", ":"); // Colon
+        trimmed = trimmed.replaceAll("\\s*'\\s*", "'"); // Apostrophe
         trimmed = trimmed.replaceAll("\\s*\\-\\s*", "-"); // Dash
         trimmed = trimmed.replaceAll("\\s+", " ").trim(); // Remove extra spaces again
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -28,7 +28,7 @@ public class Email {
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;

--- a/src/main/java/seedu/address/model/person/Nric.java
+++ b/src/main/java/seedu/address/model/person/Nric.java
@@ -17,7 +17,7 @@ public class Nric {
      * The NRIC must follow a specific format starting with an uppercase letter, followed by 7
      * digits, and ending with an uppercase letter.
      */
-    public static final String VALIDATION_REGEX = "^[A-Z][0-9]{7}[A-Z]$";
+    public static final String VALIDATION_REGEX = "^[S|F|M|T|G][0-9]{7}[A-Z]$";
 
     public final String value;
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -28,7 +28,7 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_newPerson_success() {
-        Person validPerson = new PersonBuilder().withNric("A0123456A").build();
+        Person validPerson = new PersonBuilder().withNric("T0123456A").build();
 
         Model expectedModel = new ModelManager(model.getKlinix(), new UserPrefs());
         expectedModel.addPerson(validPerson);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -29,7 +29,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "Rachel sig/ma";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -57,9 +57,9 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
+        assertTrue(Email.isValidEmail("a@b.cd")); // minimal
+        assertTrue(Email.isValidEmail("test@localhost.com")); // alphabets only
+        assertTrue(Email.isValidEmail("123@145.123")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
@@ -68,10 +68,10 @@ public class EmailTest {
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("valid@abc.email");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("valid@abc.email")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -83,6 +83,6 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@abc.email")));
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `ParserUtil` class and its test cases to improve the handling of name parsing. The most important changes include renaming and refactoring the `smartTrim` method to `smartTrimName`, and updating the test cases to reflect the new parsing logic.

Improvements to name parsing:

* [`src/main/java/seedu/address/logic/parser/ParserUtil.java`](diffhunk://#diff-a55c628b588fd4f5ae8e335751c2452e6f40cf82174203a5821de6ff8b2d6038L61-R61): Renamed `smartTrim` to `smartTrimName` and updated its logic to handle specific characters more effectively, ensuring proper trimming and formatting of names. [[1]](diffhunk://#diff-a55c628b588fd4f5ae8e335751c2452e6f40cf82174203a5821de6ff8b2d6038L61-R61) [[2]](diffhunk://#diff-a55c628b588fd4f5ae8e335751c2452e6f40cf82174203a5821de6ff8b2d6038R283-R296)

Updates to test cases:

* [`src/test/java/seedu/address/logic/parser/ParserUtilTest.java`](diffhunk://#diff-ea1ddc1697d96e6e91f3ff74631e77043f61f67aab2530c644f399a5695e897fL32-R32): Modified the `INVALID_NAME` constant to test the new parsing logic with a more complex invalid name example.