### PR TITLE
Improve command usage formatting for appointment commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkAppointmentVisitedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAppointmentVisitedCommand.java
@@ -20,7 +20,7 @@ public class MarkAppointmentVisitedCommand extends Command {
     public static final String COMMAND_WORD = "markappt";
     public static final String MESSAGE_SUCCESS = "Marked appointment as visited for person %s:\n%s";
     public static final String MESSAGE_INDEX_OUT_OF_BOUNDS = "Index is out of bounds.";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks an appointment as visited. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks an appointment as visited. \n"
             + "Parameters: "
             + "INDEX (must be a positive integer) "
             + PREFIX_NRIC + "[NRIC]'\n"

--- a/src/main/java/seedu/address/logic/commands/UnmarkAppointmentVisitedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkAppointmentVisitedCommand.java
@@ -20,7 +20,7 @@ public class UnmarkAppointmentVisitedCommand extends Command {
     public static final String COMMAND_WORD = "unmarkappt";
     public static final String MESSAGE_SUCCESS = "Marked appointment as not visited for person %s:\n%s";
     public static final String MESSAGE_INDEX_OUT_OF_BOUNDS = "Index is out of bounds.";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks an appointment as not visited."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks an appointment as not visited. \n"
             + "Parameters: "
             + "INDEX (must be a positive integer) "
             + PREFIX_NRIC + "[NRIC]'\n"

--- a/src/main/java/seedu/address/logic/commands/ViewAppointmentByDateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewAppointmentByDateCommand.java
@@ -14,8 +14,8 @@ import seedu.address.model.Model;
  */
 public class ViewAppointmentByDateCommand extends Command {
     public static final String COMMAND_WORD = "appton";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": View appointments by date. "
-            + "Parameters: "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": View appointments by date. \n"
+            + "Parameter: "
             + "DATE\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_DATE + "23-03-2025";


### PR DESCRIPTION
This pull request includes updates to the usage messages of several command classes to improve readability by adding line breaks. The most important changes include modifications to `MarkAppointmentVisitedCommand`, `UnmarkAppointmentVisitedCommand`, and `ViewAppointmentByDateCommand`.

Updates to usage messages:

* [`src/main/java/seedu/address/logic/commands/MarkAppointmentVisitedCommand.java`](diffhunk://#diff-84eb750d63965cedc1490b7d9ccc6d0f2e422759016261631d67e94323d2e2d9L23-R23): Added a line break to the `MESSAGE_USAGE` string for better readability.
* [`src/main/java/seedu/address/logic/commands/UnmarkAppointmentVisitedCommand.java`](diffhunk://#diff-ca09d90117f3c60826eadd88101fe9333102506b03d1754a4369821b6ba3ad5cL23-R23): Added a line break to the `MESSAGE_USAGE` string for better readability.
* [`src/main/java/seedu/address/logic/commands/ViewAppointmentByDateCommand.java`](diffhunk://#diff-956eb95109dc1c18d67a55c828d3730a829af016f773f6f09f4cdfbda691da44L17-R18): Added a line break to the `MESSAGE_USAGE` string and corrected the parameter label.